### PR TITLE
ALARMS: Added C++ interface to alarm system

### DIFF
--- a/command/sub8_alarm/CMakeLists.txt
+++ b/command/sub8_alarm/CMakeLists.txt
@@ -1,18 +1,61 @@
 cmake_minimum_required(VERSION 2.8.3)
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 project(sub8_alarm)
 
 find_package(catkin REQUIRED COMPONENTS
-  rospy rostest
+  rospy rostest roscpp sub8_msgs
+)
+
+set(catkin_LIBRARIES
+  ${catkin_LIBRARIES}
 )
 
 catkin_python_setup()
-catkin_package()
+
+catkin_package(
+  CATKIN_DEPENDS roscpp sub8_msgs
+  DEPENDS system_lib
+)
+
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  include
+)
+
+# Build a shared lib for C++ alarm_helpers
+add_library(
+  ${PROJECT_NAME}
+  sub8_alarm/alarm_helpers.cc
+)
+
+add_dependencies(
+  ${PROJECT_NAME}
+  sub8_msgs_generate_msgs_cpp
+)
+
+# Export headers
+install(
+  DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
 # Add folders to be run by python nosetests
 if(CATKIN_ENABLE_TESTING)
-    catkin_add_nosetests(test_alarms/test_alarm_helpers.py)
-    add_rostest(test_alarms/alarm_integration.test)
+  catkin_add_nosetests(test_alarms/test_alarm_helpers.py)
+  add_rostest(test_alarms/alarm_integration.test)
+endif()
+
+# Gtest for C++ alarms
+if(CATKIN_ENABLE_TESTING)
+  add_rostest_gtest(alarm_integration_cpp_tests 
+  	test_alarms/cpp/alarm_integration_cpp.test
+    test_alarms/cpp/test_alarm_helpers.cc
+    sub8_alarm/alarm_helpers.cc
+  )
+
+  target_link_libraries(
+  	alarm_integration_cpp_tests 
+  	${catkin_LIBRARIES}
+  	${PROJECT_NAME}
+  )
 endif()

--- a/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
+++ b/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
@@ -1,0 +1,69 @@
+/**
+ * Author: Patrick Emami
+ * Date: 11/9/2015
+ */
+
+#include <ros/ros.h>
+#include <string>
+#include <cstddef>
+
+#include "sub8_msgs/Alarm.h"
+
+namespace sub8 {
+
+class AlarmRaiser;
+typedef boost::shared_ptr<AlarmRaiser> AlarmRaiserPtr;
+
+class AlarmBroadcaster;
+typedef boost::shared_ptr<AlarmBroadcaster> AlarmBroadcasterPtr;
+
+typedef boost::shared_ptr<ros::Publisher> PublisherPtr; 
+
+class AlarmBroadcaster {
+ public:
+  // Initiates a ros publisher for sending alarms on the /alarm topic
+  AlarmBroadcaster(boost::shared_ptr<ros::NodeHandle> n);
+
+  // Factory method for creating new AlarmRaiser objects
+  AlarmRaiserPtr addAlarm(const std::string& name, bool action_required = false,
+                          int severity = 2,
+                          const std::string& problem_description = "",
+                          const std::string& parameters = "");
+
+ private:
+  const std::string _node_name = ros::this_node::getName();
+  std::vector<AlarmRaiserPtr> _alarms;
+  PublisherPtr _alarm_publisher;
+};
+
+class AlarmRaiser {
+ public:
+  // Used to generate alarm messages
+  AlarmRaiser(const std::string& alarm_name, const std::string& node_name,
+              PublisherPtr& alarm_publisher, bool action_required = false,
+              int severity = 2, const std::string& problem_description = "",
+              const std::string& parameters = "");
+
+  boost::shared_ptr<sub8_msgs::Alarm> raiseAlarm(
+      const std::string& problem_description, const std::string& parameters) const;
+
+  // Getters for alarm info
+  const std::string getAlarmName() const;
+  const std::string getNodeName() const;
+  const std::string getProblemDescription() const;
+
+  bool isActionRequired() const;
+  int getSeverity() const;
+
+ private:
+  const std::string _alarm_name;
+  const std::string _node_name;
+  const std::string _problem_description;
+  const std::string _parameters; 
+
+  bool _action_required;
+  int _severity;
+
+  PublisherPtr _alarm_publisher;
+};
+}

--- a/command/sub8_alarm/package.xml
+++ b/command/sub8_alarm/package.xml
@@ -4,11 +4,17 @@
   <version>1.0.0</version>
   <description>The sub8_alarm package</description>
   <maintainer email="jpanikulam@ufl.edu">jacob</maintainer>
+  <maintainer email="pemami@ufl.edu">patrick</maintainer>
+
   <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rostest</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sub8_msgs</build_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sub8_msgs</run_depend>
   <export>
   </export>
 </package>

--- a/command/sub8_alarm/sub8_alarm/alarm_helpers.cc
+++ b/command/sub8_alarm/sub8_alarm/alarm_helpers.cc
@@ -1,0 +1,88 @@
+/**
+ * Author: Patrick Emami
+ * Date: 11/9/2015
+ */
+
+#include "sub8_alarm/alarm_helpers.h"
+#include "std_msgs/Header.h"
+#include <string>
+
+using sub8::AlarmBroadcaster;
+using sub8::AlarmRaiserPtr;
+using sub8::AlarmRaiser;
+using sub8::PublisherPtr;
+
+AlarmBroadcaster::AlarmBroadcaster(boost::shared_ptr<ros::NodeHandle> n) {
+  // create Publisher
+  _alarm_publisher = boost::make_shared<ros::Publisher>(
+      n->advertise<sub8_msgs::Alarm>("/alarm", 10));
+}
+
+AlarmRaiserPtr AlarmBroadcaster::addAlarm(
+    const std::string& name, bool action_required, int severity,
+    const std::string& problem_description, const std::string& parameters) {
+  AlarmRaiserPtr new_alarm(new AlarmRaiser(name, _node_name, _alarm_publisher,
+                                           action_required, severity,
+                                           problem_description, parameters));
+  // Add the new alarm to the list of alarms
+  // maintained by the AlarmBroadcaster
+  _alarms.push_back(new_alarm);
+  return new_alarm;
+}
+
+AlarmRaiser::AlarmRaiser(const std::string& alarm_name,
+                         const std::string& node_name,
+                         PublisherPtr& alarm_publisher, bool action_required,
+                         int severity, const std::string& problem_description,
+                         const std::string& parameters)
+    : _alarm_name(alarm_name),
+      _node_name(node_name),
+      _alarm_publisher(alarm_publisher),
+
+      _action_required(action_required),
+      _severity(severity),
+      _problem_description(problem_description),
+      _parameters(parameters) {
+  // Verify severity is valid
+  // Q: What do if it isn't?
+  // A: Build an AI that will read over
+  // our code and correct the severity levels
+  // for us
+}
+
+boost::shared_ptr<sub8_msgs::Alarm> AlarmRaiser::raiseAlarm(
+    const std::string& problem_description,
+    const std::string& parameters) const {
+  // assert((_problem_description != "") || (problem_description != ""));
+
+  std::string pd =
+      (problem_description != "") ? problem_description : _problem_description;
+
+  std::string params = (parameters != "") ? parameters : _parameters;
+
+  std_msgs::Header alarm_header;
+  alarm_header.stamp = ros::Time::now();
+  boost::shared_ptr<sub8_msgs::Alarm> alarm_msg(new sub8_msgs::Alarm());
+  alarm_msg->header = alarm_header;
+  alarm_msg->action_required = _action_required;
+  alarm_msg->problem_description = problem_description;
+  alarm_msg->parameters = params;
+  alarm_msg->severity = _severity;
+  alarm_msg->alarm_name = _alarm_name;
+  alarm_msg->node_name = _node_name;
+
+  _alarm_publisher->publish(alarm_msg);
+  return alarm_msg;
+}
+
+const std::string AlarmRaiser::getAlarmName() const { return _alarm_name; }
+
+const std::string AlarmRaiser::getNodeName() const { return _node_name; }
+
+const std::string AlarmRaiser::getProblemDescription() const {
+  return _problem_description;
+}
+
+bool AlarmRaiser::isActionRequired() const { return _action_required; }
+
+int AlarmRaiser::getSeverity() const { return _severity; }

--- a/command/sub8_alarm/test_alarms/cpp/alarm_integration_cpp.test
+++ b/command/sub8_alarm/test_alarms/cpp/alarm_integration_cpp.test
@@ -1,0 +1,4 @@
+<launch>
+  <node pkg="sub8_alarm" type="alarm_handler.py" name="alarm_handler" />
+  <test test-name="sub8_alarm_integration_cpp" name="alarm_helpers_test" pkg="sub8_alarm" type="alarm_integration_cpp_tests" />
+</launch>

--- a/command/sub8_alarm/test_alarms/cpp/test_alarm_helpers.cc
+++ b/command/sub8_alarm/test_alarms/cpp/test_alarm_helpers.cc
@@ -1,0 +1,111 @@
+/**
+ * Author: Patrick Emami
+ * Date: 11/11/2015
+ */
+
+#include "gtest/gtest.h"
+#include "sub8_alarm/alarm_helpers.h"
+#include <string>
+
+using sub8::AlarmBroadcaster;
+using sub8::AlarmBroadcasterPtr;
+using sub8::AlarmRaiser;
+using sub8::AlarmRaiserPtr;
+using sub8::PublisherPtr;
+
+class AlarmHelpersTest : public ::testing::Test {
+ public:
+  AlarmHelpersTest() : _node_handle(new ros::NodeHandle()){};
+  boost::shared_ptr<ros::NodeHandle> getNodeHandle() { return _node_handle; }
+
+ private:
+  boost::shared_ptr<ros::NodeHandle> _node_handle;
+};
+
+TEST_F(AlarmHelpersTest, testAlarmBroadcasterConstructor) {
+  AlarmBroadcasterPtr alarm_ptr(new AlarmBroadcaster(getNodeHandle()));
+}
+
+TEST_F(AlarmHelpersTest, testAlarmRaiserConstructor) {
+  const std::string alarm_name = "test_alarm";
+  const std::string node_name = ros::this_node::getName();
+  const std::string empty = "";
+
+  // For testing, just pass in a null Publisher object
+  // It's okay to allow this behavior, since this constructor
+  // is never explicitly called
+  PublisherPtr pub = nullptr;
+  AlarmRaiserPtr alarm_raiser_ptr(new AlarmRaiser(alarm_name, node_name, pub));
+
+  EXPECT_EQ(alarm_name, alarm_raiser_ptr->getAlarmName());
+  EXPECT_EQ(node_name, alarm_raiser_ptr->getNodeName());
+  EXPECT_EQ(empty, alarm_raiser_ptr->getProblemDescription());
+  EXPECT_EQ(false, alarm_raiser_ptr->isActionRequired());
+}
+
+TEST_F(AlarmHelpersTest, testAddAlarm) {
+  AlarmBroadcasterPtr alarm_ptr(new AlarmBroadcaster(getNodeHandle()));
+  const std::string alarm_name = "test_alarm";
+  const std::string node_name = ros::this_node::getName();
+  const std::string empty = "";
+
+  // Sets action_required to true
+  AlarmRaiserPtr new_alarm = alarm_ptr->addAlarm(alarm_name, true);
+
+  // Assert members are set
+  EXPECT_EQ(alarm_name, new_alarm->getAlarmName());
+  EXPECT_EQ(node_name, new_alarm->getNodeName());
+  EXPECT_EQ(empty, new_alarm->getProblemDescription());
+  EXPECT_EQ(true, new_alarm->isActionRequired());
+}
+
+TEST_F(AlarmHelpersTest, testRaisingAlarm) {
+  AlarmBroadcasterPtr alarm_ptr(new AlarmBroadcaster(getNodeHandle()));
+  const std::string alarm_name = "test_alarm";
+  const std::string node_name = ros::this_node::getName();
+  const std::string empty = "";
+
+  AlarmRaiserPtr new_alarm = alarm_ptr->addAlarm(alarm_name, true);
+
+  const std::string problem_description = "Entering black hole";
+  const std::string parameters = "";
+
+  boost::shared_ptr<sub8_msgs::Alarm> alarm_msg =
+      new_alarm->raiseAlarm(problem_description, parameters);
+
+  EXPECT_EQ(problem_description, alarm_msg->problem_description);
+  EXPECT_EQ(node_name, alarm_msg->node_name);
+  EXPECT_EQ(true, alarm_msg->action_required);
+  EXPECT_EQ(2, alarm_msg->severity);
+}
+
+// Test building and decoding JSON
+TEST_F(AlarmHelpersTest, testJSONBlob) {
+  AlarmBroadcasterPtr alarm_ptr(new AlarmBroadcaster(getNodeHandle()));
+  const std::string alarm_name = "test_alarm";
+  const std::string node_name = ros::this_node::getName();
+  const std::string empty = "";
+  // TODO: Test whether the AlarmHandler actually accepts this
+  const std::string json_string =
+      "{ \"ShowMe\": [\"What\", \"You\", \"Got\"] }";
+
+  AlarmRaiserPtr new_alarm = alarm_ptr->addAlarm(alarm_name, true);
+
+  const std::string problem_description = "Entering black hole";
+
+  // The AlarmHandler node will decode the JSON
+  boost::shared_ptr<sub8_msgs::Alarm> alarm_msg =
+      new_alarm->raiseAlarm(problem_description, json_string);
+
+  EXPECT_EQ(problem_description, alarm_msg->problem_description);
+  EXPECT_EQ(node_name, alarm_msg->node_name);
+  EXPECT_EQ(true, alarm_msg->action_required);
+  EXPECT_EQ(2, alarm_msg->severity);
+  EXPECT_EQ(json_string, alarm_msg->parameters);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "alarm_helpers_test");
+  return RUN_ALL_TESTS();
+}

--- a/gnc/sub8_trajectory_generator/CMakeLists.txt
+++ b/gnc/sub8_trajectory_generator/CMakeLists.txt
@@ -7,14 +7,15 @@ find_package(catkin REQUIRED COMPONENTS roscpp geometry_msgs sub8_msgs)
 find_package(OMPL REQUIRED)
 find_package(Boost REQUIRED)
 
-
 set(catkin_LIBRARIES
 	${catkin_LIBRARIES}
 )
+
 catkin_package(
    	CATKIN_DEPENDS roscpp sub8_msgs
    	DEPENDS system_lib
 )
+
 include_directories(
   	include/${PROJECT_NAME}
  	${catkin_INCLUDE_DIRS}

--- a/gnc/sub8_trajectory_generator/package.xml
+++ b/gnc/sub8_trajectory_generator/package.xml
@@ -17,7 +17,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>OMPL</build_depend>
   <build_depend>sub8_msgs</build_depend>
-  
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>OMPL</run_depend>


### PR DESCRIPTION
Added the AlarmBroadcaster and AlarmRaiser
classes, to be used to publish
messages on the /alarm topic. These
msgs will be consumed by the AlarmHandler.

*Note: The user can optionally supply
a JSON blob containing useful information within
the alarm msg. For C++, this must be in a
well-formed JSON string.

TODO: Will test linking libsub8_alarm.so with the TGEN 
when I add alarms to the TGEN next week
