### PR TITLE
ALARMS: Auto-generate alarms with JSON (C++)

### DIFF
--- a/command/sub8_alarm/CMakeLists.txt
+++ b/command/sub8_alarm/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 project(sub8_alarm)
 
 find_package(catkin REQUIRED COMPONENTS
-  rospy rostest roscpp sub8_msgs
+  rospy rostest roscpp roslib sub8_msgs
 )
 
 set(catkin_LIBRARIES
@@ -13,7 +13,7 @@ set(catkin_LIBRARIES
 catkin_python_setup()
 
 catkin_package(
-  CATKIN_DEPENDS roscpp sub8_msgs
+  CATKIN_DEPENDS roscpp sub8_msgs roslib
   DEPENDS system_lib
 )
 

--- a/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
+++ b/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
@@ -3,6 +3,9 @@
  * Date: 11/9/2015
  */
 
+#ifndef ALARM_HELPERS_H_
+#define ALARM_HELPERS_H_
+
 #include <ros/ros.h>
 #include <string>
 #include <boost/filesystem.hpp>  // directory iterators, etc
@@ -76,3 +79,5 @@ class AlarmRaiser {
   PublisherPtr _alarm_publisher;
 };
 }
+
+#endif /* ALARM_HELPERS_H_ */

--- a/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
+++ b/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
@@ -5,9 +5,11 @@
 
 #include <ros/ros.h>
 #include <string>
-#include <cstddef>
+#include <boost/filesystem.hpp>  // directory iterators, etc
 
 #include "sub8_msgs/Alarm.h"
+ 
+namespace fs = ::boost::filesystem;
 
 namespace sub8 {
 
@@ -17,15 +19,21 @@ typedef boost::shared_ptr<AlarmRaiser> AlarmRaiserPtr;
 class AlarmBroadcaster;
 typedef boost::shared_ptr<AlarmBroadcaster> AlarmBroadcasterPtr;
 
-typedef boost::shared_ptr<ros::Publisher> PublisherPtr; 
+typedef boost::shared_ptr<ros::Publisher> PublisherPtr;
 
 class AlarmBroadcaster {
  public:
   // Initiates a ros publisher for sending alarms on the /alarm topic
   AlarmBroadcaster(boost::shared_ptr<ros::NodeHandle> n);
 
+  // Given a directory of JSON files, parse and auto-generate all alarms
+  // and return them as a list.
+  // Returns as false if parsing the JSON files failed.
+  bool addAlarms(const fs::path& dirname, const std::string& ext,
+                 std::vector<AlarmRaiserPtr>& alarms);
+
   // Factory method for creating new AlarmRaiser objects
-  AlarmRaiserPtr addAlarm(const std::string& name, bool action_required = false,
+  AlarmRaiserPtr addAlarm(const std::string& name, bool action_required = true,
                           int severity = 2,
                           const std::string& problem_description = "",
                           const std::string& parameters = "");
@@ -40,12 +48,13 @@ class AlarmRaiser {
  public:
   // Used to generate alarm messages
   AlarmRaiser(const std::string& alarm_name, const std::string& node_name,
-              PublisherPtr& alarm_publisher, bool action_required = false,
+              PublisherPtr& alarm_publisher, bool action_required = true,
               int severity = 2, const std::string& problem_description = "",
               const std::string& parameters = "");
 
   boost::shared_ptr<sub8_msgs::Alarm> raiseAlarm(
-      const std::string& problem_description, const std::string& parameters) const;
+      const std::string& problem_description,
+      const std::string& parameters) const;
 
   // Getters for alarm info
   const std::string getAlarmName() const;
@@ -59,7 +68,7 @@ class AlarmRaiser {
   const std::string _alarm_name;
   const std::string _node_name;
   const std::string _problem_description;
-  const std::string _parameters; 
+  const std::string _parameters;
 
   bool _action_required;
   int _severity;

--- a/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
+++ b/command/sub8_alarm/include/sub8_alarm/alarm_helpers.h
@@ -11,7 +11,7 @@
 #include <boost/filesystem.hpp>  // directory iterators, etc
 
 #include "sub8_msgs/Alarm.h"
- 
+
 namespace fs = ::boost::filesystem;
 
 namespace sub8 {
@@ -32,10 +32,9 @@ class AlarmBroadcaster {
   // Given a directory of JSON files, parse and auto-generate all alarms
   // and return them as a list.
   // Returns as false if parsing the JSON files failed.
-  bool addAlarms(const fs::path& dirname, const std::string& ext,
-                 std::vector<AlarmRaiserPtr>& alarms);
+  bool addAlarms(const fs::path& dirname, std::vector<AlarmRaiserPtr>& alarms);
 
-  // Factory method for creating new AlarmRaiser objects
+  // Factory method for creating individual AlarmRaiser objects
   AlarmRaiserPtr addAlarm(const std::string& name, bool action_required = true,
                           int severity = 2,
                           const std::string& problem_description = "",

--- a/command/sub8_alarm/package.xml
+++ b/command/sub8_alarm/package.xml
@@ -11,9 +11,11 @@
   <build_depend>rostest</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>roslib</build_depend>
   <build_depend>sub8_msgs</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>roslib</run_depend>
   <run_depend>sub8_msgs</run_depend>
   <export>
   </export>

--- a/command/sub8_alarm/setup.py
+++ b/command/sub8_alarm/setup.py
@@ -5,10 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
-    packages=['sub8_alarm'],
-    package_dir={
-        '':'sub8_alarm',
-    },
+     packages=['sub8_alarm'],
 )
 
 setup(**setup_args)

--- a/command/sub8_alarm/setup.py
+++ b/command/sub8_alarm/setup.py
@@ -7,7 +7,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 setup_args = generate_distutils_setup(
     packages=['sub8_alarm'],
     package_dir={
-        'sub8_alarm': '.',
+        '':'sub8_alarm',
     },
 )
 

--- a/command/sub8_alarm/sub8_alarm/alarm_helpers.cc
+++ b/command/sub8_alarm/sub8_alarm/alarm_helpers.cc
@@ -34,9 +34,9 @@ AlarmRaiserPtr AlarmBroadcaster::addAlarm(
 }
 
 bool AlarmBroadcaster::addAlarms(const fs::path& dirname,
-                                 const std::string& ext,
                                  std::vector<AlarmRaiserPtr>& alarms) {
   std::vector<std::string> paths;
+  const std::string ext = ".json"; 
 
   // alarm attributes
   std::string alarm_name;
@@ -46,7 +46,7 @@ bool AlarmBroadcaster::addAlarms(const fs::path& dirname,
   std::string parameters;
 
   if (!fs::exists(dirname) || !fs::is_directory(dirname)) {
-    ROS_WARN("Could not find the specified alarms directory");
+    ROS_WARN("Could not find the following alarms directory %s", dirname.string().c_str());
     return false;
   }
 
@@ -63,7 +63,7 @@ bool AlarmBroadcaster::addAlarms(const fs::path& dirname,
     }
   }
 
-  // no files with extension ext were found
+  // no json files were found
   if (paths.empty()) {
     ROS_WARN("Could not find any files with extension %s", ext.c_str());
     return false;

--- a/command/sub8_alarm/sub8_alarm/alarm_helpers.cc
+++ b/command/sub8_alarm/sub8_alarm/alarm_helpers.cc
@@ -5,7 +5,10 @@
 
 #include "sub8_alarm/alarm_helpers.h"
 #include "std_msgs/Header.h"
+#include <ros/ros.h>
 #include <string>
+#include <boost/property_tree/ptree.hpp>        // ptree
+#include <boost/property_tree/json_parser.hpp>  // read_json
 
 using sub8::AlarmBroadcaster;
 using sub8::AlarmRaiserPtr;
@@ -28,6 +31,68 @@ AlarmRaiserPtr AlarmBroadcaster::addAlarm(
   // maintained by the AlarmBroadcaster
   _alarms.push_back(new_alarm);
   return new_alarm;
+}
+
+bool AlarmBroadcaster::addAlarms(const fs::path& dirname,
+                                 const std::string& ext,
+                                 std::vector<AlarmRaiserPtr>& alarms) {
+  std::vector<std::string> paths;
+
+  // alarm attributes
+  std::string alarm_name;
+  bool action_required;
+  int severity;
+  std::string problem_description;
+  std::string parameters;
+
+  if (!fs::exists(dirname) || !fs::is_directory(dirname)) {
+    ROS_WARN("Could not find the specified alarms directory");
+    return false;
+  }
+
+  fs::recursive_directory_iterator it(dirname);
+  fs::recursive_directory_iterator endit;
+
+  // iterate over all files in the directory and store all with the extension in
+  // a vector for further processing
+  while (it != endit) {
+    if (fs::is_regular_file(*it) && it->path().extension() == ext) {
+      // Store the dirname + filename
+      paths.push_back(it->path().string());
+      ++it;
+    }
+  }
+
+  // no files with extension ext were found
+  if (paths.empty()) {
+    ROS_WARN("Could not find any files with extension %s", ext.c_str());
+    return false;
+  }
+
+  for (std::vector<std::string>::iterator it = paths.begin(); it != paths.end();
+       ++it) {
+    boost::property_tree::ptree pt;
+    try {
+      boost::property_tree::read_json(*it, pt);
+
+      alarm_name = pt.get<std::string>("alarm_name");
+      action_required = pt.get<bool>("action_required");
+      severity = pt.get<int>("severity");
+      problem_description = pt.get<std::string>("problem_description");
+      parameters = pt.get<std::string>("parameters");
+    } catch (const boost::property_tree::ptree_error& e) {
+      ROS_WARN("%s", e.what());
+      return false;
+    }
+
+    // add the new alarm
+    addAlarm(alarm_name, action_required, severity, problem_description,
+             parameters);
+  }
+
+  alarms = _alarms;
+
+  return true;
 }
 
 AlarmRaiser::AlarmRaiser(const std::string& alarm_name,

--- a/command/sub8_alarm/test_alarms/cpp/cfg/test_alarm_1.json
+++ b/command/sub8_alarm/test_alarms/cpp/cfg/test_alarm_1.json
@@ -1,0 +1,15 @@
+{
+	"alarm_name":"test_alarm_1",
+	"action_required":true,
+	"severity":0,
+	"problem_description":"This is test alarm 1",
+	"parameters":
+		{
+			"ShowMe":
+				[
+					"What",
+					"You",
+					"Got"
+				]
+		}
+}

--- a/command/sub8_alarm/test_alarms/cpp/cfg/test_alarm_2.json
+++ b/command/sub8_alarm/test_alarms/cpp/cfg/test_alarm_2.json
@@ -1,0 +1,15 @@
+{
+	"alarm_name":"test_alarm_2",
+	"action_required":true,
+	"severity":0,
+	"problem_description":"This is test alarm 2",
+	"parameters":
+		{
+			"Am":
+				[
+					"I",
+					"just",
+					"JSON?"
+				]
+		}
+}

--- a/command/sub8_alarm/test_alarms/cpp/test_alarm_helpers.cc
+++ b/command/sub8_alarm/test_alarms/cpp/test_alarm_helpers.cc
@@ -187,8 +187,7 @@ TEST_F(AlarmHelpersTest, testAddAlarms) {
   // Will break if our file structure changes :/
   fs::path dirname(pkg_path + file_sep + "test_alarms" + file_sep + "cpp" +
                    file_sep + "cfg");
-  const std::string ext = ".json";
-  bool result = alarm_ptr->addAlarms(dirname, ext, test_alarms);
+  bool result = alarm_ptr->addAlarms(dirname, test_alarms);
 
   ASSERT_EQ(true, result);
   EXPECT_EQ("test_alarm_1", test_alarms[0]->getAlarmName());

--- a/drivers/sub8_videoray_m5_thruster/setup.py
+++ b/drivers/sub8_videoray_m5_thruster/setup.py
@@ -6,6 +6,5 @@ from catkin_pkg.python_setup import generate_distutils_setup
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['sub8_thruster_comm'],
-    package_dir={'sub8_thruster_comm': '.'},
 )
 setup(**setup_args)

--- a/simulation/sub8_simulation/setup.py
+++ b/simulation/sub8_simulation/setup.py
@@ -6,6 +6,5 @@ from catkin_pkg.python_setup import generate_distutils_setup
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['sub8_sim_tools'],
-    package_dir={'sub8_sim_tools': '.'},
 )
 setup(**setup_args)

--- a/utils/sub8_ros_tools/setup.py
+++ b/utils/sub8_ros_tools/setup.py
@@ -6,10 +6,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['sub8_ros_tools', 'sub8_misc_tools'],
-    package_dir={
-        'sub8_ros_tools': '.',
-        'sub8_misc_tools': '.',
-    },
 )
 
 setup(**setup_args)


### PR DESCRIPTION
To auto-generate alarms, create a directory in your ROS
package and place json files there.
The json files just have to have entries whose
names correspond to the alarm attributes. See test_alarms/cpp/cfg
for an example.

The user simply needs to supply the path to the config directory;
to do this, use `ros::package::getPath()` and append
the config directory to that. See test_alarms/cpp/test_alarm_helpers
for an example.

A lot of C++ code is saved by doing this, since you no longer
need to individually specify attributes and add
each alarm in your source code. The more alarms you have
for your package, the more lines of code saved!
