### PR TITLE
MAKE: Fix random build failures due to unbuilt pkg

### DIFF
--- a/command/sub8_alarm/CMakeLists.txt
+++ b/command/sub8_alarm/CMakeLists.txt
@@ -30,8 +30,10 @@ add_library(
 
 add_dependencies(
   ${PROJECT_NAME}
-  sub8_msgs_generate_msgs_cpp
+  sub8_msgs_generate_messages_cpp
+  ${catkin_EXPORTED_TARGETS}
 )
+
 
 # Export headers
 install(
@@ -47,14 +49,14 @@ endif()
 
 # Gtest for C++ alarms
 if(CATKIN_ENABLE_TESTING)
-  add_rostest_gtest(alarm_integration_cpp_tests 
+  add_rostest_gtest(alarm_integration_cpp_tests
   	test_alarms/cpp/alarm_integration_cpp.test
     test_alarms/cpp/test_alarm_helpers.cc
     sub8_alarm/alarm_helpers.cc
   )
 
   target_link_libraries(
-  	alarm_integration_cpp_tests 
+  	alarm_integration_cpp_tests
   	${catkin_LIBRARIES}
   	${PROJECT_NAME}
   )

--- a/gnc/sub8_trajectory_generator/CMakeLists.txt
+++ b/gnc/sub8_trajectory_generator/CMakeLists.txt
@@ -13,7 +13,7 @@ set(catkin_LIBRARIES
 
 catkin_package(
    	CATKIN_DEPENDS roscpp sub8_msgs
-   	DEPENDS system_lib
+   	DEPENDS system_lib sub8_msgs
 )
 
 include_directories(
@@ -25,25 +25,27 @@ include_directories(
 
 
 add_executable(
-	${PROJECT_NAME} 
-	src/trajectory_generator.cc 
+	${PROJECT_NAME}
+	src/trajectory_generator.cc
 	src/sub8_state_space.cc
 	src/sub8_space_information.cc
 	src/sub8_state_validity_checker.cc
 	src/sub8_tgen_manager.cc
 )
 
-target_link_libraries(${PROJECT_NAME}
-	${catkin_LIBRARIES}
-	${OMPL_LIBRARIES}
+
+target_link_libraries(
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    ${OMPL_LIBRARIES}
 )
 
-add_dependencies(
-  ${PROJECT_NAME}
-  sub8_msgs_generate_msgs_cpp
+add_dependencies(${PROJECT_NAME}
+    sub8_msgs_generate_messages_cpp
+    ${catkin_EXPORTED_TARGETS}
 )
 
-catkin_add_gtest(${PROJECT_NAME}_unit_tests 
+catkin_add_gtest(${PROJECT_NAME}_unit_tests
 	test/sub8_state_space_test.cc
 	test/sub8_state_validity_checker_test.cc
 	test/sub8_space_information_test.cc
@@ -54,6 +56,7 @@ catkin_add_gtest(${PROJECT_NAME}_unit_tests
 	src/sub8_state_validity_checker.cc
 	src/sub8_tgen_manager.cc
 )
+
 
 target_link_libraries(
 	${PROJECT_NAME}_unit_tests


### PR DESCRIPTION
Single commit PR fixing the thing we talked about before, where we = @pemami4911 and myself
- Typos in sub8_alarm and sub8_trajectory_generator
  - "sub8_msgs_generate_msgs_cpp" --> "sub8_msgs_generate_messages_cpp"
