### PR TITLE
MAPPER: Make thruster_out alarm faster

### DIFF
--- a/command/sub8_alarm/sub8_alarm/alarms/thruster_out.py
+++ b/command/sub8_alarm/sub8_alarm/alarms/thruster_out.py
@@ -1,29 +1,22 @@
 import rospy
-from sub8_ros_tools import wait_for_param
 from sub8_msgs.srv import UpdateThrusterLayout
 
 
 class ThrusterOut(object):
     alarm_name = 'thruster_out'
+
     def __init__(self):
         # Keep some knowledge of which thrusters we have working
-        self.thruster_layout = wait_for_param('busses')
+        self.dropped_thrusters = []
         self.update_layout = rospy.ServiceProxy('update_thruster_layout', UpdateThrusterLayout)
 
     def drop_thruster(self, thruster_name):
+        self.dropped_thrusters.append(thruster_name)
         # Drop a single thruster
-        remaining_thrusters = []
-        for port in self.thruster_layout:
-            if thruster_name in port['thrusters']:
-                port['thrusters'].pop(thruster_name)
-
-            remaining_thrusters.extend(port['thrusters'].keys())
-
         rospy.logwarn("Dropping thuster {}".format(thruster_name))
         # a priori: Each thruster name is a string, do not need to map(str, remaining_thursters)
-        rospy.logwarn("Thrusters remaining " + ', '.join(remaining_thrusters))
+        rospy.logwarn("Dropped thrusters: " + ', '.join(self.dropped_thrusters))
 
     def handle(self, time_sent, parameters):
         self.drop_thruster(parameters['thruster_name'])
-        rospy.set_param('busses', self.thruster_layout)
-        self.update_layout()
+        self.update_layout(self.dropped_thrusters)

--- a/gnc/sub8_thruster_mapper/launch/thruster_mapper.launch
+++ b/gnc/sub8_thruster_mapper/launch/thruster_mapper.launch
@@ -1,6 +1,6 @@
 <launch>
     <rosparam>
-      busses: 
+      busses:
         - port: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A403IMC9-if00-port0
           thrusters:
             FLV: {
@@ -34,13 +34,13 @@
             BLV: {
               node_id: 14,
               frame_id: /base_link,
-              position: [-0.1583, 0.169, 0.0142], 
+              position: [-0.1583, 0.169, 0.0142],
               direction: [0, 0, 1]
             }
             BLL: {
               node_id: 15,
               frame_id: /base_link,
-              position: [-0.2678, 0.2795, 0], 
+              position: [-0.2678, 0.2795, 0],
               direction: [0.866, 0.5, 0]
             }
         - port: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A403IN03-if00-port0

--- a/gnc/sub8_thruster_mapper/test/test_sub8_mapper.py
+++ b/gnc/sub8_thruster_mapper/test/test_sub8_mapper.py
@@ -81,6 +81,7 @@ class TestMapThrusters(unittest.TestCase):
 
             self.assertEqual(len(self.test_data) - 1, num, msg="Could not compute wrench for " + str(wrench) + " within timeout")
             self.got_msg = False
+            rospy.sleep(0.06)  # Wait the timeout period
 
 
 if __name__ == '__main__':

--- a/gnc/sub8_thruster_mapper/test/test_sub8_mapper.test
+++ b/gnc/sub8_thruster_mapper/test/test_sub8_mapper.test
@@ -1,4 +1,7 @@
 <launch>
+  <param name="simulate" value="true" />
+  <include file="$(find sub8_videoray_m5_thruster)/launch/thruster_driver.launch" />
   <include file="$(find sub8_thruster_mapper)/launch/thruster_mapper.launch" />
+
   <test test-name="sub8_mapper_test" pkg="sub8_thruster_mapper" type="test_sub8_mapper.py" retry="1"/>
 </launch>

--- a/utils/sub8_msgs/srv/UpdateThrusterLayout.srv
+++ b/utils/sub8_msgs/srv/UpdateThrusterLayout.srv
@@ -1,1 +1,2 @@
+string[] dropped_thrusters
 ---


### PR DESCRIPTION
- and fix a few bugs related to it. 

The new process: instead of updating the bus layout parameter, a list of failed thrusters is cached, and instead of forming a new B matrix every time a thruster fails, we simply adjust the thrust bounds for all of the failed thrusters. 
