### PR TITLE
PERCEPTION: finish torpedo board full pose service

### DIFF
--- a/gnc/sub8_perception/include/sub8_pcl/cv_tools.hpp
+++ b/gnc/sub8_perception/include/sub8_pcl/cv_tools.hpp
@@ -57,7 +57,8 @@ void statistical_image_segmentation(const cv::Mat &src, cv::Mat &dest,
 		const int hist_size, const float** ranges, const int target, std::string image_name,
         const float sigma = 1.5, const float low_thresh_gain = 0.5, const float high_thresh_gain = 0.5);
 
-Eigen::Vector3f triangulate_image_coordinates(const cv::Point &pt1, const cv::Point &pt2, Eigen::Matrix3f fundamental);
+Eigen::Vector3d triangulate_image_coordinates(const cv::Point &pt1, const cv::Point &pt2, 
+											  const Eigen::Matrix3d &fundamental, const Eigen::Matrix3d &R);
 
 struct ImageWithCameraInfo
 {	
@@ -66,9 +67,10 @@ struct ImageWithCameraInfo
 		into one object. Containers of these objects can be sorted by their image_time attribute
 	*/
 	public:
-		ImageWithCameraInfo(sensor_msgs::ImageConstPtr image_msg, sensor_msgs::CameraInfoConstPtr info_msg);
-		sensor_msgs::ImageConstPtr image_msg;
-		sensor_msgs::CameraInfoConstPtr info_msg;
+		ImageWithCameraInfo(){}
+		ImageWithCameraInfo(sensor_msgs::ImageConstPtr _image_msg_ptr, sensor_msgs::CameraInfoConstPtr _info_msg_ptr);
+		sensor_msgs::ImageConstPtr image_msg_ptr;
+		sensor_msgs::CameraInfoConstPtr info_msg_ptr;
 		ros::Time image_time;
 		bool operator <(const ImageWithCameraInfo& right) const {
 			return this->image_time < right.image_time;

--- a/gnc/sub8_perception/include/sub8_pcl/torpedo_board.hpp
+++ b/gnc/sub8_perception/include/sub8_pcl/torpedo_board.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <utility>
 #include <iostream>
 
 #include <algorithm>
@@ -26,22 +27,27 @@ class Sub8TorpedoBoardDetector {
 public:
   Sub8TorpedoBoardDetector();
   ~Sub8TorpedoBoardDetector();
-  void image_callback(const sensor_msgs::ImageConstPtr &image_msg,
-                      const sensor_msgs::CameraInfoConstPtr &info_msg);
-  void determine_torpedo_board_position(const image_geometry::PinholeCameraModel &cam_model,
-                               const cv::Mat &image_raw);
+  void left_image_callback(const sensor_msgs::ImageConstPtr &image_msg_ptr,
+                      const sensor_msgs::CameraInfoConstPtr &info_msg_ptr);
+  void right_image_callback(const sensor_msgs::ImageConstPtr &image_msg_ptr,
+                      const sensor_msgs::CameraInfoConstPtr &info_msg_ptr);
+  void determine_torpedo_board_position(sub8_msgs::VisionRequest::Response &resp);
   bool request_torpedo_board_position(sub8_msgs::VisionRequest::Request &req,
                              sub8_msgs::VisionRequest::Response &resp);
   void segment_board(const cv::Mat &src, cv::Mat &dest);
-
-  void find_board_corners(const cv::Mat &segmented_board, sub::Contour &corners);
-  
-  sub::FrameHistory frame_history;
-
+  bool find_board_corners(const cv::Mat &segmented_board, sub::Contour &corners);
+  double image_proc_scale = 0.5;
+private:
   ros::NodeHandle nh;
+  ros::ServiceServer service;
 
-  image_transport::CameraSubscriber image_sub;  // ?? gcc complains if I remove parentheses
+  image_transport::CameraSubscriber left_image_sub, right_image_sub;
   image_transport::ImageTransport image_transport;
-  image_geometry::PinholeCameraModel cam_model;
+  image_geometry::PinholeCameraModel left_cam_model, right_cam_model;
 
+  sub::Contour left_corners, right_corners;
+  sub::ImageWithCameraInfo left_most_recent;
+  sub::ImageWithCameraInfo right_most_recent;
+
+  sub::RvizVisualizer rviz;
 };

--- a/gnc/sub8_perception/include/sub8_pcl/visualization.hpp
+++ b/gnc/sub8_perception/include/sub8_pcl/visualization.hpp
@@ -11,9 +11,10 @@ namespace sub {
 // ******* 3D Visualization *******
 class RvizVisualizer {
  public:
-  ros::Publisher buoy_pub;
+  ros::Publisher rviz_pub;
   ros::NodeHandle nh;
-  RvizVisualizer();
+  RvizVisualizer(std::string rviz_topic);
   void visualize_buoy(geometry_msgs::Pose &pose, std::string &frame_id);
+  void visualize_torpedo_board(geometry_msgs::Pose& pose, std::string& frame_id);
 };
 }

--- a/gnc/sub8_perception/readme.md
+++ b/gnc/sub8_perception/readme.md
@@ -33,7 +33,7 @@ To handle potential timing discrepancy, the timestamp at which the images and po
 
 ```shell
     # running
-    rosrun sub8_perception pcl_buoy
+    rosrun sub8_perception pcl_perception
 
     # requesting results
     rosservice call /vision/buoys/red "target_name: 'red'"

--- a/gnc/sub8_perception/src/sub8_pcl/buoy.cc
+++ b/gnc/sub8_perception/src/sub8_pcl/buoy.cc
@@ -4,11 +4,12 @@
 Sub8BuoyDetector::Sub8BuoyDetector()
     : vp1(0),
       vp2(1),
+      rviz("/visualization/buoys"),
 #ifdef VISUALIZE
       viewer(new pcl::visualization::PCLVisualizer("Incoming Cloud")),
 #endif
       image_transport(nh) {
-  pcl::console::print_highlight("Initializing PCL SLAM\n");
+  pcl::console::print_highlight("Initializing PCL Sub8BuoyDetector\n");
 
   // Check if radius parameter exists
   // TODO: Make this templated library code, allow defaults
@@ -33,7 +34,7 @@ Sub8BuoyDetector::Sub8BuoyDetector()
   computing = false;
   need_new_cloud = false;
 
-  pcl::console::print_highlight("--PCL SLAM Initialized\n");
+  pcl::console::print_highlight("--PCL Sub8BuoyDetector Initialized\n");
   data_sub = nh.subscribe("/stereo/points2", 1, &Sub8BuoyDetector::cloud_callback, this);
   service =
       nh.advertiseService("/vision/buoys/red", &Sub8BuoyDetector::request_buoy_position, this);
@@ -120,8 +121,8 @@ void Sub8BuoyDetector::determine_buoy_position(
   pcl_pt_3d = sub::project_uv_to_cloud(*point_cloud_raw, pt_cv_2d, camera_model);
 
   // Reprojection (Useful for visualization)
-  cv::Point2d cv_pt_uv =
-      cam_model.project3dToPixel(cv::Point3f(pcl_pt_3d.x, pcl_pt_3d.y, pcl_pt_3d.z));
+  // cv::Point2d cv_pt_uv =
+  //     cam_model.project3dToPixel(cv::Point3f(pcl_pt_3d.x, pcl_pt_3d.y, pcl_pt_3d.z));
 
   // Threshold -- > This is what must be replaced with better 2d vision
   cv::inRange(image_hsv, cv::Scalar(105, 135, 135), cv::Scalar(120, 255, 255), image_thresh);

--- a/gnc/sub8_perception/src/sub8_pcl/torpedo_board.cc
+++ b/gnc/sub8_perception/src/sub8_pcl/torpedo_board.cc
@@ -1,15 +1,28 @@
 #include <sub8_pcl/torpedo_board.hpp>
 
 Sub8TorpedoBoardDetector::Sub8TorpedoBoardDetector()
-try : frame_history("/forward_camera/image_color", 10), image_transport(nh)
+try : image_transport(nh), rviz("/visualization/torpedo_board")
 {
-  std::string img_topic = /*"/forward_camera/image_color"*/ "/stereo/left/image_raw";
-  ROS_INFO("Constructing Sub8TorpedoBoardDetector");
-  image_sub = image_transport.subscribeCamera(img_topic, 1, &Sub8TorpedoBoardDetector::image_callback, this);
-  // ROS_INFO("Subscribed to  %s ", img_topic.c_str());
+  ROS_INFO("Initializing Sub8TorpedoBoardDetector");
+  std::string img_topic_left = "/stereo/left/image_raw";
+  std::string img_topic_right = "/stereo/right/image_raw";
+  std::string service_name = "/vision/torpedo_board";
+  
+  left_image_sub = image_transport.subscribeCamera(img_topic_left, 1, &Sub8TorpedoBoardDetector::left_image_callback, this);
+  right_image_sub = image_transport.subscribeCamera(img_topic_right, 1, &Sub8TorpedoBoardDetector::right_image_callback, this);
+  
+  std::string log_msg = 
+    (boost::format("Camera subscriptions: left=%1% right=%2%") % img_topic_left % img_topic_right).str();
+  ROS_INFO(log_msg.c_str());
+
+  service =
+    nh.advertiseService(service_name, &Sub8TorpedoBoardDetector::request_torpedo_board_position, this);
+  log_msg = (boost::format("Advertisied Service: %1%") % service_name).str();
+  ROS_INFO(log_msg.c_str());
+  ROS_INFO("Sub8TorpedoBoardDetector Initialized");
 }
 catch(const std::exception &e){
-  ROS_ERROR("Error constructing Sub8TorpedoBoardDetector using initializer list: ");
+  ROS_ERROR("Exception from within Sub8TorpedoBoardDetector constructor initializer list: ");
   ROS_ERROR(e.what());
 }
 
@@ -19,41 +32,134 @@ Sub8TorpedoBoardDetector::~Sub8TorpedoBoardDetector(){
 }
 
 
-void Sub8TorpedoBoardDetector::image_callback(const sensor_msgs::ImageConstPtr &image_msg,
-                               const sensor_msgs::CameraInfoConstPtr &info_msg){
-  cv_bridge::CvImagePtr input_bridge;
-  cv::Mat current_image, segmented_board_left, segmented_board_right;
-  try {
-    input_bridge = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::BGR8);
-    current_image = input_bridge->image;
-  } catch (cv_bridge::Exception &ex) {
-    ROS_ERROR("[torpedo_board] cv_bridge: Failed to convert image");
-    return;
-  }
-  cam_model.fromCameraInfo(info_msg);
-  segment_board(current_image, segmented_board_left);
-
-  sub::Contour board_corners;
-  find_board_corners(segmented_board_left, board_corners);
-  BOOST_FOREACH(cv::Point pt, board_corners){
-    cv::circle(segmented_board_left, pt, 5, cv::Scalar(120), -1);
-  }
-#ifdef VISUALIZE
-  cv::imshow("segmented board", segmented_board_left);
-#endif
-
-  cv::waitKey(1);
+void Sub8TorpedoBoardDetector::left_image_callback(const sensor_msgs::ImageConstPtr &image_msg_ptr,
+                               const sensor_msgs::CameraInfoConstPtr &info_msg_ptr){
+  left_most_recent.image_msg_ptr = image_msg_ptr;
+  left_most_recent.info_msg_ptr = info_msg_ptr;
 }
 
 
-void Sub8TorpedoBoardDetector::determine_torpedo_board_position(const image_geometry::PinholeCameraModel &cam_model,
-                                             const cv::Mat &image_raw){
+void Sub8TorpedoBoardDetector::right_image_callback(const sensor_msgs::ImageConstPtr &image_msg_ptr,
+                               const sensor_msgs::CameraInfoConstPtr &info_msg_ptr){
+  right_most_recent.image_msg_ptr = image_msg_ptr;
+  right_most_recent.info_msg_ptr = info_msg_ptr;
+}
 
+
+void Sub8TorpedoBoardDetector::determine_torpedo_board_position(sub8_msgs::VisionRequest::Response &resp){
+  cv_bridge::CvImagePtr input_bridge;
+  cv::Mat current_image_left, current_image_right, segmented_board_left, segmented_board_right;
+
+  // Get the most recent frames and camera info for both cameras
+  try {
+    input_bridge = cv_bridge::toCvCopy(left_most_recent.image_msg_ptr, sensor_msgs::image_encodings::BGR8);
+    current_image_left = input_bridge->image;
+    left_cam_model.fromCameraInfo(left_most_recent.info_msg_ptr);
+
+    input_bridge = cv_bridge::toCvCopy(right_most_recent.image_msg_ptr, sensor_msgs::image_encodings::BGR8);
+    current_image_right = input_bridge->image;
+    right_cam_model.fromCameraInfo(right_most_recent.info_msg_ptr);
+  } catch (cv_bridge::Exception &ex) {
+    ROS_ERROR("[torpedo_board] cv_bridge: Failed to convert images");
+    return;
+  }
+
+  // Segment Board and find image coordinates of board corners
+  sub::Contour board_corners_left, board_corners_right;
+  segment_board(current_image_left, segmented_board_left);
+  segment_board(current_image_right, segmented_board_right);
+  bool found_left = find_board_corners(segmented_board_left, board_corners_left);
+  bool found_right = find_board_corners(segmented_board_right, board_corners_right);
+  if(!found_left || !found_right){
+    resp.found = false;
+    ROS_INFO("Unable to detect torpedo board");
+    return;
+  }
+
+  // Match corresponding corner coordinates from both images
+  std::vector< std::pair<cv::Point, cv::Point> > corresponding_corners;
+  BOOST_FOREACH(cv::Point left_corner, board_corners_left){
+    double min_distance = std::numeric_limits<double>::infinity();
+    int matching_idx = 0;
+    for(size_t j = 0; j < board_corners_right.size(); j++){
+      cv::Point diff = left_corner - board_corners_right[j];
+      double distance = sqrt(pow(diff.x, 2.0) + pow(diff.y, 2.0));
+      if(distance < min_distance){
+        min_distance = distance;
+        matching_idx = j;
+      }
+    }
+    corresponding_corners.push_back(std::pair<cv::Point, cv::Point>(left_corner, board_corners_right[matching_idx]));
+  }
+
+  // Get Fundamental Matrix from full camera projection matrices
+  // Procedure described in section 8.2.2 of The Bible
+  cv::Matx34d P_L = left_cam_model.fullProjectionMatrix();
+  cv::Matx34d P_R = right_cam_model.fullProjectionMatrix();
+  cv::Matx41d C(0, 0, 0, 1);
+  cv::Matx43d P_L_inv;
+  cv::invert(P_L, P_L_inv);
+  cv::Matx31d epipole_im2 = P_R * C;
+  cv::Matx33d cross_with_epipole_im2( 0, -epipole_im2(2, 0),  epipole_im2(1, 0),
+                     epipole_im2(2, 0),                  0, -epipole_im2(0, 0),
+                    -epipole_im2(1, 0),  epipole_im2(0, 0),                  0);
+  cv::Matx33d fundamental_mat = cross_with_epipole_im2 * ( P_R * P_L_inv);
+  cv::Matx33d rot_matx_right = right_cam_model.rotationMatrix();
+  Eigen::Matrix3d fundamental_matrix;
+  fundamental_matrix << fundamental_mat(0, 0), fundamental_mat(0, 1), fundamental_mat(0, 2),
+                        fundamental_mat(1, 0), fundamental_mat(1, 1), fundamental_mat(1, 2),
+                        fundamental_mat(2, 0), fundamental_mat(2, 1), fundamental_mat(2, 2);
+
+  // Calculate 3d coordinates of corner points
+  Eigen::Matrix3d R;
+  R << rot_matx_right(0, 0), rot_matx_right(0, 1), rot_matx_right(0, 2),
+       rot_matx_right(1, 0), rot_matx_right(1, 1), rot_matx_right(1, 2),
+       rot_matx_right(2, 0), rot_matx_right(2, 1), rot_matx_right(2, 2);
+  std::vector<Eigen::Vector3d> corners_3d;
+  for(size_t i = 0; i < corresponding_corners.size(); i++){
+    cv::Point pt_L, pt_R;
+    pt_L = corresponding_corners[i].first;
+    pt_R = corresponding_corners[i].second;
+    Eigen::Vector3d current_corner = sub::triangulate_image_coordinates(pt_L, pt_R, fundamental_matrix, R);
+    corners_3d.push_back(current_corner);
+  }
+
+  // Calculate board position (center of board) in 3d
+  Eigen::Vector3d position;
+  Eigen::Vector3d sum(0,0,0);
+  BOOST_FOREACH(Eigen::Vector3d corner, corners_3d){
+    sum = sum + corner;
+  }
+  position = sum / 4.0;
+
+  // Calculate normal vector to torpedo board
+  Eigen::Vector3d normal_vector, edge1, edge2;
+  edge1 = corners_3d[0] - corners_3d[1];
+  edge2 = corners_3d[2] - corners_3d[1];
+  normal_vector = edge1.cross(edge2);
+  normal_vector = normal_vector.normalized();
+
+  // Calculate Quaternion representing rotation from z-axis to normal vector
+  Eigen::Vector3d z_axis(0, 0, 1);
+  Eigen::Quaterniond orientation;
+  orientation.setFromTwoVectors(z_axis, normal_vector);
+
+  // Fill service response fields
+  std::string tf_frame = left_cam_model.tfFrame();
+  resp.pose.header.frame_id = tf_frame;
+  resp.pose.header.stamp = ros::Time::now();
+  tf::pointEigenToMsg(position, resp.pose.pose.position);
+  tf::quaternionEigenToMsg(orientation, resp.pose.pose.orientation);
+  resp.found = true;
 }
 
 
 bool Sub8TorpedoBoardDetector::request_torpedo_board_position(sub8_msgs::VisionRequest::Request &req,
                                            sub8_msgs::VisionRequest::Response &resp){
+  std::string left_tf_frame = left_cam_model.tfFrame();
+  Eigen::Vector3f position;
+  determine_torpedo_board_position(resp);
+  rviz.visualize_torpedo_board(resp.pose.pose, left_tf_frame);
   return true;
 }
 
@@ -63,7 +169,7 @@ void Sub8TorpedoBoardDetector::segment_board(const cv::Mat &src, cv::Mat &dest){
   // Preprocessing
   cv::Mat processing_size_image, hsv_image, hue_blurred, sat_blurred;
   std::vector<cv::Mat> hsv_channels;
-  cv::resize(src, processing_size_image, cv::Size(0,0), 0.5, 0.5);
+  cv::resize(src, processing_size_image, cv::Size(0,0), image_proc_scale, 0.5);
   cv::cvtColor(processing_size_image, hsv_image, CV_BGR2HSV);
   cv::split(hsv_image, hsv_channels);
   cv::medianBlur(hsv_channels[0], hue_blurred, 5); // Magic num: 5 (might need tuning)
@@ -95,7 +201,7 @@ void Sub8TorpedoBoardDetector::segment_board(const cv::Mat &src, cv::Mat &dest){
 }
 
 
-void Sub8TorpedoBoardDetector::find_board_corners(const cv::Mat &segmented_board, sub::Contour &corners){
+bool Sub8TorpedoBoardDetector::find_board_corners(const cv::Mat &segmented_board, sub::Contour &corners){
   cv::Mat convex_hull_working_img = segmented_board.clone();
   std::vector<sub::Contour> contours, connected_contours;
   sub::Contour convex_hull, corner_points;
@@ -123,9 +229,8 @@ void Sub8TorpedoBoardDetector::find_board_corners(const cv::Mat &segmented_board
 
   // Find convex hull of connected panels
   cv::convexHull(connected_contours[0], convex_hull);
-  cv::Point board_centroid = sub::contour_centroid(convex_hull);
   ROS_INFO((boost::format("convex hull size = %1%") % convex_hull.size()).str().c_str() );
-  int poly_pts = convex_hull.size();
+  size_t poly_pts = convex_hull.size();
   const int max_iterations = 50;
   int total_iterations = 0;
   double epsilon = 1;
@@ -143,7 +248,14 @@ void Sub8TorpedoBoardDetector::find_board_corners(const cv::Mat &segmented_board
   }
   if(!corners_success) ROS_WARN("Failed to generate the four corners of board from image");
   else{
-    ROS_INFO((boost::format("corners size = %1% epsilon = %2% iterations = %3%") % convex_hull.size() % epsilon % total_iterations).str().c_str() );
+    ROS_INFO((boost::format("corners size = %1% epsilon = %2% iters = %3%") % convex_hull.size() % epsilon % total_iterations).str().c_str() );
+  }
+
+  // Scale corner image coordinates back up to original scale
+  for(size_t i = 0; i < convex_hull.size(); i++){
+    convex_hull[i].x *= (1 / image_proc_scale);
+    convex_hull[i].y *= (1 / image_proc_scale);
   }
   corners = convex_hull;
+  return corners_success;
 }

--- a/gnc/sub8_perception/src/sub8_pcl/visualization.cc
+++ b/gnc/sub8_perception/src/sub8_pcl/visualization.cc
@@ -3,8 +3,8 @@
 
 namespace sub {
 
-RvizVisualizer::RvizVisualizer() {
-  buoy_pub = nh.advertise<visualization_msgs::Marker>("/visualization/buoys", 1);
+RvizVisualizer::RvizVisualizer(std::string rviz_topic) {
+  rviz_pub = nh.advertise<visualization_msgs::Marker>(rviz_topic, 1);
   ros::spinOnce();
   // Give these guys some time to get ready
   ros::Duration(0.5).sleep();
@@ -28,7 +28,7 @@ void RvizVisualizer::visualize_buoy(geometry_msgs::Pose& pose, std::string& fram
   marker.color.r = 0.2;
   marker.color.g = 1.0;
   marker.color.b = 0.0;
-  buoy_pub.publish(marker);
+  rviz_pub.publish(marker);
 
   // Generate text to overlay on the buoy (TODO: Put the text offset from the buoy)
   marker.header.stamp = ros::Time();
@@ -50,6 +50,49 @@ void RvizVisualizer::visualize_buoy(geometry_msgs::Pose& pose, std::string& fram
   marker.color.g = 0.2;
   marker.color.b = 0.1;
   marker.text = "Buoy Bump Target";
-  buoy_pub.publish(marker);
+  rviz_pub.publish(marker);
+}
+
+void RvizVisualizer::visualize_torpedo_board(geometry_msgs::Pose& pose, std::string& frame_id) {
+  visualization_msgs::Marker marker;
+
+  // Generate sphere marker for the buoy
+  marker.header.frame_id = frame_id;
+  marker.header.stamp = ros::Time();
+  marker.ns = "sub";
+  marker.id = 0;
+  marker.type = visualization_msgs::Marker::SPHERE;
+  marker.action = visualization_msgs::Marker::ADD;
+  marker.pose = pose;
+  marker.scale.x = 0.2;
+  marker.scale.y = 0.2;
+  marker.scale.z = 0.2;
+  marker.color.a = 0.8;
+  marker.color.r = 0.2;
+  marker.color.g = 1.0;
+  marker.color.b = 0.0;
+  rviz_pub.publish(marker);
+
+  // Generate text to overlay on the buoy (TODO: Put the text offset from the buoy)
+  marker.header.stamp = ros::Time();
+  marker.ns = "sub";
+  marker.id = 1;
+  marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
+  marker.action = visualization_msgs::Marker::ADD;
+  marker.pose.position.x = pose.position.x;
+  // y is down in computer vision world
+  marker.pose.position.y = pose.position.y - 0.25;
+  marker.pose.position.z = pose.position.z;
+  // Orientation doesn't matter for this guy
+  marker.scale.x = 0.2;
+  marker.scale.y = 0.2;
+  marker.scale.z = 0.1;
+
+  marker.color.a = 1.0;
+  marker.color.r = 1.0;
+  marker.color.g = 1.0;
+  marker.color.b = 0.0;
+  marker.text = "Torpedo Board Centroid";
+  rviz_pub.publish(marker);
 }
 }


### PR DESCRIPTION
This is the first complete draft of the Sub8TorpedoBoardDetector Class. The interface for requesting the board's pose is the same as for the Sub8BuoyDetector except that the request's target name is not taken into account. 

This also visualizes the pose through Rviz.

When calling the service through the terminal (`rosservice call /vision/torpedo_board "target_name: 'N/A'"`), I get the following error, but I can't figure out why: 

> pcl_perception: /opt/ros/indigo/include/image_geometry/pinhole_camera_model.h:284: std::string image_geometry::PinholeCameraModel::tfFrame() const: Assertion `initialized()' failed.

@jpanikulam, I don't want you to do my debugging for me, but I won't be able to go to the pool day tomorrow, and if it's something trivial for you to fix, then you could test getting full board pose tomorrow.
