### PR TITLE
ALARMS: Add alarm listener class to __init__.py

### DIFF
--- a/command/sub8_alarm/sub8_alarm/__init__.py
+++ b/command/sub8_alarm/sub8_alarm/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 
 from alarm_helpers import AlarmBroadcaster
+from alarm_helpers import AlarmListener
 from . import alarms


### PR DESCRIPTION
One line fix to allow the alarm listener class to be used outside of the files local to the same folder. 
