### PR TITLE
VISION: Add particle filter for multi-view pose estimation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 *.mtl
 *.bin
 *.hex
+
+*.dae

--- a/command/sub8_missions/missions/torpedos.py
+++ b/command/sub8_missions/missions/torpedos.py
@@ -1,38 +1,39 @@
 from txros import util, tf
 import numpy as np
 
+
 @util.cancellableInlineCallbacks
 def run(sub):
 
-	# dive to mission start depth
-	print "descending to set course mission depth"
-	mission_start_depth = 2.15		# meters
-	sub_singleton.to_height(mission_start_depth)
+    # dive to mission start depth
+    print "descending to set course mission depth"
+    mission_start_depth = 2.15        # meters
+    sub.to_height(mission_start_depth)
 
-	# TODO: Rotate in place until torpedo board is detected for several consecutive frames
-	print "Executing search pattern"
+    # TODO: Rotate in place until torpedo board is detected for several consecutive frames
+    print "Executing search pattern"
 
-	# TODO: once the board moves out of our field of view, stop rotating
-	print "Found torpedo board"
+    # TODO: once the board moves out of our field of view, stop rotating
+    print "Found torpedo board"
 
-	# TODO: move sub to closest point on the ray eminating from the board centroid normal to the board
+    # TODO: move sub to closest point on the ray eminating from the board centroid normal to the board
 
-	# TODO: align x-axis of sub with z axis of torpedo board
-	print "aligning to torpedo board"
+    # TODO: align x-axis of sub with z axis of torpedo board
+    print "aligning to torpedo board"
 
-	# TODO: approach board until it occupies most of our field of view, save this position as the best obserbation position
-	print "Approaching board"
+    # TODO: approach board until it occupies most of our field of view, save this position as the best obserbation position
+    print "Approaching board"
 
-	# TODO: Determine which of the targets has the sliding door covering it
-	print "Examining targets"
+    # TODO: Determine which of the targets has the sliding door covering it
+    print "Examining targets"
 
-	# TODO: While moving in the plane parallel to the board align bottom paddle to a position on the board slightly to the right of the door handle
-	print "Aligning to door removal position"
+    # TODO: While moving in the plane parallel to the board align bottom paddle to a position on the board slightly to the right of the door handle
+    print "Aligning to door removal position"
 
-	# TODO: move directly torwards the board until the bottom pattle is aligned with the handle
-	print "Approaching board"
+    # TODO: move directly torwards the board until the bottom pattle is aligned with the handle
+    print "Approaching board"
 
-	# TODO: move to the left for about one foot
-	print "Removing target cover"
+    # TODO: move to the left for about one foot
+    print "Removing target cover"
 
-	# TODO: 
+    # TODO:

--- a/gnc/sub8_perception/nodes/buoy_2d.py
+++ b/gnc/sub8_perception/nodes/buoy_2d.py
@@ -91,9 +91,7 @@ class BuoyFinder:
     def ncc(self, image, mean_thresh, scale=15):
         '''Compute normalized cross correlation w.r.t a shadowed pillbox fcn
 
-        TODO:
-            Compute the kernel only once
-                (Too cheap to need)
+        The expected scale will vary, so we don't cache it
         '''
         kernel = np.ones((scale, scale)) * -1
         midpoint = (scale // 2, scale // 2)

--- a/gnc/sub8_perception/sub8_vision_tools/estimation.py
+++ b/gnc/sub8_perception/sub8_vision_tools/estimation.py
@@ -1,0 +1,260 @@
+from __future__ import division
+import image_geometry
+import numpy as np
+from scipy import stats
+from mayavi import mlab
+
+
+class ProjectionParticleFilter(object):
+    def __init__(self, camera_model, num_particles=10000, max_Z=25, aggressive=True):
+        """
+        :param camera_model: ros image_geometry PinholeCameraModel, must be initialized
+        :param num_particles: How many particles to use, we can operate comfortably with 100,000
+        :param max_Z: The maximum depth to search in
+        :param aggressive: Use a gaussian error distributions instead of error**2, much more aggressive
+            may sometimes throw probability did not sum to one errors (because it is too aggressive!)
+
+        Functions:
+        :function column_vectorize: Make a row vector into a column vector, and do nothing to a column vector
+
+        """
+        assert isinstance(camera_model, image_geometry.PinholeCameraModel), "Must be pinhole camera"
+        self.aggressive = aggressive
+        self.min_Z = 0.0
+        self.max_Z = max_Z
+
+        self.camera_model = camera_model
+        self.K = np.array(camera_model.fullIntrinsicMatrix(), dtype=np.float32)
+        self.K_inv = np.linalg.inv(self.K)
+
+        self.num_particles = num_particles
+        self.particles = np.random.uniform((-25, -25, self.min_Z), (25, 25, self.max_Z), size=(self.num_particles, 3)).transpose()
+        self.weights = np.ones(self.num_particles)
+        self.weights = self.weights / np.sum(self.weights)
+        self.t = np.zeros(3)
+        self.R = np.diag([1.0, 1.0, 1.0])
+        self.first_observation = True
+
+    def get_best(self):
+        ind = np.argmax(self.weights)
+        return self.particles[:, ind]
+
+    def column_vectorize(self, v):
+        return np.reshape(v, (len(v), 1))
+
+    def in_fov(self, pts):
+        projected_h = self.K.dot(pts)
+        not_infinite = projected_h[2, :] > 1e-5
+        projected = projected_h[:2, :] / projected_h[2, :]
+
+        # I acknowledge that the image edges are NOT guaranteed to be at (2cx, 2cy)
+        in_image = np.logical_and(
+            np.all(projected > self.column_vectorize((0.0, 0.0)), axis=0),
+            np.all(projected < self.column_vectorize((self.camera_model.cx() * 2, self.camera_model.cy() * 2)), axis=0)
+        )
+        in_front = pts[2, :] > 0
+        in_fov = np.logical_and(np.logical_and(
+            in_image, in_front
+        ), not_infinite)
+        print np.sum(not_infinite)
+        return in_fov
+
+    def set_pose(self, t, R):
+        assert R.shape == (3, 3), "Rotation must be 3x3 rotation matrix"
+        assert len(t) == 3, "Translation vector must be of length 3"
+        self.t = self.column_vectorize(t)
+        self.R = R
+
+    def _transform_pts(self, t, R):
+        """Supply a transform to the camera frame"""
+        particles = np.copy(np.dot(R.transpose(), self.particles) - R.transpose().dot(t))
+        return particles
+
+    def get_ray(self, observation):
+        """Returns a ray in camera frame pointing towards the observation
+
+            self.R.dot(observation) will give the ray in world frame
+            self.t would be the base of the ray
+        """
+        obs_column = self.column_vectorize(observation)
+        ray = self.K_inv.dot(np.vstack([obs_column, 1.0]))
+        unit_ray = ray / np.linalg.norm(ray)
+        return unit_ray
+
+    def _reset_to_ray(self, observation, weights=None):
+        unit_ray = self.R.dot(self.get_ray(observation))
+
+        if weights is None:
+            self.particles = self.t + (np.random.uniform(self.min_Z, self.max_Z, size=self.num_particles) * unit_ray)
+            self.particles += np.random.normal(scale=(0.1, 0.1, 0.1), size=(self.num_particles, 3)).transpose()
+
+        else:
+            average_p = 0.2 * np.average(weights)
+            self.particles[:, weights < average_p] = np.reshape(-self.t, (3, 1)) + np.random.uniform(
+                self.min_Z,
+                self.max_Z,
+                size=self.particles[:, weights < average_p]
+            ) * unit_ray
+
+        self.first_observation = False
+
+    def observe(self, observation):
+        """
+        observation should be a column vector
+
+        TODO
+            - Must shuffle instead of relying on state transition distribution
+        """
+        if self.first_observation:
+            self._reset_to_ray(observation)
+            self.first_observation = False
+
+        # compute p(z | x)
+        particles = self._transform_pts(self.t, self.R)
+        expected_obs_h = self.K.dot(particles)
+        infront = np.sum(self.in_fov(particles))
+        print 'In front:', infront
+        if infront < 100:
+            print "Not enough in front"
+            return
+        expected_obs = expected_obs_h[:2, :] / expected_obs_h[2, :]
+
+        error = np.linalg.norm(expected_obs - observation, axis=0)
+
+        if self.aggressive:
+            prob = stats.norm.pdf(error, scale=5.0) * stats.uniform.pdf(particles[2, :], loc=0.0, scale=self.max_Z)
+        else:
+            prob = np.power(error ** 2, -1)
+
+        normalized_prob = prob / np.sum(prob)
+
+        to_sample = int(self.num_particles)
+        choice_indices = np.random.choice(
+            a=np.arange(particles.shape[1]),
+            p=normalized_prob,
+            size=to_sample,
+            replace=True,
+        )
+
+        choices = self.particles[:, choice_indices]
+
+        self.particles = choices + np.random.normal(scale=(0.01, 0.01, 0.01), size=(self.num_particles, 3)).transpose()
+
+        new_weights = normalized_prob[choice_indices]
+        weights = new_weights
+        self.weights = weights / np.sum(weights)
+
+
+def draw_particles(ppf, color_hsv=(1.0, 0.2, 1.0), scale=0.05):
+    mlab.points3d(
+        ppf.particles[0, :][::20],
+        ppf.particles[1, :][::20],
+        ppf.particles[2, :][::20],
+        scale_factor=scale,
+        color=color_hsv,
+        colormap='hsv'
+    )
+    mlab.axes()
+
+
+def draw_cameras(observations, cameras):
+    for observation, camera in zip(observations, cameras):
+        t, R = camera
+        draw_camera(t, R)
+        draw_line(t, t + (R.dot(observation.flatten()) * 15), color=(0.0, 1.0, 0.0))
+
+
+def draw_camera(t, R):
+    colors = (
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+    )
+    for line, color in zip(R, colors):
+        draw_line(t, t + line, color=color)
+
+    mlab.points3d(
+        [t[0]],
+        [t[1]],
+        [t[2]],
+        color=(0.0, 1.0, 0.0),
+        scale_factor=0.3
+    )
+
+
+def draw_line(pt_1, pt_2, color=(1.0, 0.0, 0.0)):
+    mlab.plot3d(
+        np.hstack([pt_1[0], pt_2[0]]),
+        np.hstack([pt_1[1], pt_2[1]]),
+        np.hstack([pt_1[2], pt_2[2]]),
+        color=color
+    )
+
+
+def main():
+    import sub8_ros_tools
+    import time
+    import rospy
+    rospy.init_node('test_estimation')
+    q = sub8_ros_tools.Image_Subscriber('/stereo/left/image_rect_color')
+    while(q.camera_info is None):
+        time.sleep(0.1)
+
+    camera_model = image_geometry.PinholeCameraModel()
+    camera_model.fromCameraInfo(q.camera_info)
+
+    ppf = ProjectionParticleFilter(camera_model, 100000)
+    real = np.array([1.0, 3.0, 7.0])
+    projected_h = ppf.K.dot(real)
+    projected = projected_h[:2] / projected_h[2]
+
+    print 'starting'
+    R = np.diag([1.0, 1.0, 1.0])
+    camera_t = np.array([0.0, 0.0, 0.0])
+    cameras = []
+    observations = []
+
+    max_k = 3
+    for k in range(max_k):
+
+        if k < 1:
+            print 'doop'
+            camera_t = np.array([0.0, -8.0, 7.0])
+            R = np.array([
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, -1.0, 0.0],
+            ])
+
+        else:
+            camera_t = np.hstack([(np.random.random(2) - 0.5) * 5, 0.0])
+
+        projected_h = ppf.K.dot(np.dot(R.transpose(), real) - R.transpose().dot(camera_t))
+        print projected_h
+        projected = projected_h[:2] / projected_h[2]
+
+        obs_final = projected + np.random.normal(scale=3.0, size=2)
+
+        cameras.append((camera_t, R))
+        observations.append(ppf.get_ray(obs_final))
+        draw_cameras(observations, cameras)
+        mlab.show()
+        draw_particles(ppf, color_hsv=((k + 1) / (max_k + 1), 0.7, 0.8), scale=0.1 * ((k + 1) / max_k))
+
+        ppf.set_pose(camera_t, R)
+        ppf.observe(np.reshape(obs_final, (2, 1)))
+
+    print 'cov:', np.diag(np.cov(ppf.particles))
+    best = ppf.get_best()
+
+    print 'best'
+    print best, best / np.linalg.norm(best)
+    print real, real / np.linalg.norm(real)
+    draw_cameras(observations, cameras)
+    draw_particles(ppf, color_hsv=((k + 1) / (max_k + 1), 0.7, 0.8), scale=0.1 * ((k + 1) / max_k))
+
+    mlab.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/gnc/sub8_perception/sub8_vision_tools/estimation.py
+++ b/gnc/sub8_perception/sub8_vision_tools/estimation.py
@@ -6,7 +6,8 @@ from mayavi import mlab
 
 
 class ProjectionParticleFilter(object):
-    def __init__(self, camera_model, num_particles=10000, max_Z=25, aggressive=True):
+    def __init__(self, camera_model, num_particles=10000, max_Z=25, observation_noise=5.0, jitter_prob=0.2, salting=0.1,
+                 aggressive=True):
         """A particle filter for estimating pose from multiple camera views
 
         ppf = ProjectionParticleFitler(image_geometry.PinholeCameraModel(msg.cameraInfo))
@@ -14,14 +15,21 @@ class ProjectionParticleFilter(object):
             centroid = my_object_finder.find(images[k])
             ppf.observe(centroid)
 
-        Calling ppf.observe returns
+        Calling ppf.observe returns the current best estimate and the particle covariance
         Note: Covariance is not a complete measure of certainty
 
         :param camera_model: ros image_geometry PinholeCameraModel, must be initialized
         :param num_particles: How many particles to use, we can operate comfortably with 100,000
         :param max_Z: The maximum depth to search in
+        :param observation_noise: The standard-deviation of the noise (in units of pixels)
+        :param jitter_prob: Probability of a completely random measurement
+        :param salting: std-def of how much we'll spice up the estimates!
         :param aggressive: Use a gaussian error distributions instead of error**2, much more aggressive
             may sometimes throw probability did not sum to one errors (because it is too aggressive!)
+
+        Implementation Notes:
+            - The measurement pdf I am using is not z ~ N(K * x | sig**2, mu)
+                - It is instead the p(z | x) + p(z | total randomness)
 
         TODO:
             - If probabilities fall below something reasonable, more frequently do reset_to_ray
@@ -31,18 +39,25 @@ class ProjectionParticleFilter(object):
         self.aggressive = aggressive
         self.min_Z = 0.0
         self.max_Z = max_Z
-
+        self.salt = salting
+        self.observation_noise = observation_noise
+        self.jitter = jitter_prob
         self.camera_model = camera_model
+
+        self.image_size = (self.camera_model.cx() * 2, self.camera_model.cy() * 2)
         self.K = np.array(camera_model.fullIntrinsicMatrix(), dtype=np.float32)
         self.K_inv = np.linalg.inv(self.K)
 
         self.num_particles = num_particles
+        self.jitter_pdf = stats.uniform(loc=0.0, scale=max(self.image_size))
+
+        # This line doesn't *necessarily* do something
         self.particles = np.random.uniform((-25, -25, self.min_Z), (25, 25, self.max_Z), size=(self.num_particles, 3)).transpose()
         self.weights = np.ones(self.num_particles)
         self.weights = self.weights / np.sum(self.weights)
         self.t = np.zeros(3)
         self.R = np.diag([1.0, 1.0, 1.0])
-        self.first_observation = True
+        self.on_first_observation = True
 
     def get_best(self):
         """Return the best point and the diagonal of the covariance matrix of our particles
@@ -51,7 +66,10 @@ class ProjectionParticleFilter(object):
                 being smaller than the radius of your target
         """
         ind = np.argmax(self.weights)
-        return self.particles[:, ind], np.diag(np.cov(self.particles))
+        weighted_avg = np.average(self.particles, axis=1, weights=self.weights)
+        # return self.particles[:, ind], np.diag(np.cov(self.particles))
+        # This allows us to handle a fair bit of random noise
+        return weighted_avg, np.diag(np.cov(self.particles))
 
     def column_vectorize(self, v):
         """Converts a row vector to a column vector, does nothing to a column vector"""
@@ -67,7 +85,7 @@ class ProjectionParticleFilter(object):
         # but PinholeCameraModel doesn't contain resolution information :/
         in_image = np.logical_and(
             np.all(projected > self.column_vectorize((0.0, 0.0)), axis=0),
-            np.all(projected < self.column_vectorize((self.camera_model.cx() * 2, self.camera_model.cy() * 2)), axis=0)
+            np.all(projected < self.column_vectorize(self.image_size), axis=0)
         )
         in_front = pts[2, :] > 0
         in_fov = np.logical_and(np.logical_and(
@@ -110,8 +128,9 @@ class ProjectionParticleFilter(object):
         unit_ray = self.R.dot(self.get_ray(observation))
 
         if weights is None:
+            # This favors distant particles, which is not what we want
             self.particles = self.t + (np.random.uniform(self.min_Z, self.max_Z, size=self.num_particles) * unit_ray)
-            self.particles += np.random.normal(scale=(0.1, 0.1, 0.1), size=(self.num_particles, 3)).transpose()
+            self.particles += np.random.normal(scale=(self.salt, self.salt, self.salt), size=(self.num_particles, 3)).transpose()
 
         else:
             average_p = 0.2 * np.average(weights)
@@ -121,7 +140,9 @@ class ProjectionParticleFilter(object):
                 size=self.particles[:, weights < average_p]
             ) * unit_ray
 
-        self.first_observation = False
+            self.particles[:, weights < average_p] += np.random.normal(
+                scale=(self.salt, self.salt, self.salt), size=(self.num_particles, 3)
+            ).transpose()
 
     def observe(self, observation):
         """Measurement-update, take a single-pixel observation
@@ -134,13 +155,14 @@ class ProjectionParticleFilter(object):
         TODO
             - Must shuffle instead of relying on state transition distribution
         """
-        if self.first_observation:
+        if self.on_first_observation:
             self._reset_to_ray(observation)
-            self.first_observation = False
+            self.on_first_observation = False
 
-        # compute p(z | x)
+        # Compute expected z
         particles = self._transform_pts(self.t, self.R)
         expected_obs_h = self.K.dot(particles)
+        expected_obs = expected_obs_h[:2, :] / expected_obs_h[2, :]
 
         # Check how many particles are in the field of view, if we have a problem, don't try
         infront = np.sum(self.in_fov(particles))
@@ -148,17 +170,23 @@ class ProjectionParticleFilter(object):
             # TODO: Do a partial ray-reset
             return
 
-        expected_obs = expected_obs_h[:2, :] / expected_obs_h[2, :]
-
+        # Compute p(z | x)
         error = np.linalg.norm(expected_obs - observation, axis=0)
-
         if self.aggressive:
-            prob = stats.norm.pdf(error, scale=5.0) * stats.uniform.pdf(particles[2, :], loc=0.0, scale=self.max_Z)
-        else:
-            prob = np.power(error ** 2, -1)
+            # TODO: logpdf instead
+            z_prob = stats.uniform.pdf(particles[2, :], loc=0.0, scale=self.max_Z)
+            reprojection_prob = stats.norm.pdf(error, scale=self.observation_noise)
 
+            # p(z | x) = (1 - p_outlier ) * p(err | sigma) + (p_outlier * p(err | random))
+            prob = ((1 - self.jitter) * (z_prob * reprojection_prob)) + (self.jitter * self.jitter_pdf.pdf(error))
+
+        else:
+            prob = ((1 - self.jitter) * np.power(error ** 2, -1)) + (self.jitter * self.jitter_pdf.pdf(error))
+
+        # Normalize because we suck
         normalized_prob = prob / np.sum(prob)
 
+        # Importance sampling
         to_sample = int(self.num_particles)
         choice_indices = np.random.choice(
             a=np.arange(particles.shape[1]),
@@ -166,14 +194,19 @@ class ProjectionParticleFilter(object):
             size=to_sample,
             replace=True,
         )
-
         choices = self.particles[:, choice_indices]
 
-        self.particles = choices + np.random.normal(scale=(0.01, 0.01, 0.01), size=(self.num_particles, 3)).transpose()
+        # Update our particles
+        self.particles = choices + np.random.normal(
+            scale=(self.salt, self.salt, self.salt),
+            size=(self.num_particles, 3)
+        ).transpose()
 
+        # Update our weights
         new_weights = normalized_prob[choice_indices]
         weights = new_weights
         self.weights = weights / np.sum(weights)
+        return self.get_best()
 
 
 def draw_particles(ppf, color_hsv=(1.0, 0.2, 1.0), scale=0.05):
@@ -228,6 +261,8 @@ def draw_line(pt_1, pt_2, color=(1.0, 0.0, 0.0)):
 
 
 def main():
+    """Here's some stupid demo code
+    """
     import sub8_ros_tools
     import time
     import rospy
@@ -241,6 +276,8 @@ def main():
 
     ppf = ProjectionParticleFilter(camera_model, 100000)
     real = np.array([1.0, 3.0, 7.0])
+    p_wrong = 0.4
+
     projected_h = ppf.K.dot(real)
     projected = projected_h[:2] / projected_h[2]
 
@@ -250,9 +287,9 @@ def main():
     cameras = []
     observations = []
 
-    max_k = 3
+    cov = np.array([100, 100, 100])
+    max_k = 15
     for k in range(max_k):
-
         if k < 1:
             camera_t = np.array([0.0, -8.0, 7.0])
             R = np.array([
@@ -262,28 +299,34 @@ def main():
             ])
 
         else:
+            R = np.diag([1.0, 1.0, 1.0])
             camera_t = np.hstack([(np.random.random(2) - 0.5) * 5, 0.0])
 
-        projected_h = ppf.K.dot(np.dot(R.transpose(), real) - R.transpose().dot(camera_t))
-        projected = projected_h[:2] / projected_h[2]
+        if (np.random.random() < p_wrong) and (k > 1):
+            print "Doing a random observation"
+            projected = np.random.random(2) * np.array([640., 480.])
+        else:
+            projected_h = ppf.K.dot(np.dot(R.transpose(), real) - R.transpose().dot(camera_t))
+            projected = projected_h[:2] / projected_h[2]
 
-        obs_final = projected + np.random.normal(scale=3.0, size=2)
+        obs_final = projected + np.random.normal(scale=5.0, size=2)
 
         cameras.append((camera_t, R))
         observations.append(ppf.get_ray(obs_final))
-        draw_cameras(observations, cameras)
-        mlab.show()
-        draw_particles(ppf, color_hsv=((k + 1) / (max_k + 1), 0.7, 0.8), scale=0.1 * ((k + 1) / max_k))
+        # draw_cameras(observations, cameras)
+        # draw_particles(ppf, color_hsv=((k + 1) / (max_k + 1), 0.7, 0.8), scale=0.1 * ((k + 1) / max_k))
+        # mlab.show()
+
+        # Interpolate along hsv to get a cool heatmap effect
 
         ppf.set_pose(camera_t, R)
         ppf.observe(np.reshape(obs_final, (2, 1)))
 
-    print 'cov:', np.diag(np.cov(ppf.particles))
-    best = ppf.get_best()
+        best_v, cov = ppf.get_best()
 
-    print 'best'
-    print best, best / np.linalg.norm(best)
-    print real, real / np.linalg.norm(real)
+        print 'best', best_v
+        print 'cov', cov
+
     draw_cameras(observations, cameras)
     draw_particles(ppf, color_hsv=((k + 1) / (max_k + 1), 0.7, 0.8), scale=0.1 * ((k + 1) / max_k))
 

--- a/gnc/sub8_perception/sub8_vision_tools/rviz.py
+++ b/gnc/sub8_perception/sub8_vision_tools/rviz.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+from __future__ import division
+
+import numpy as np
+import rospy
+import visualization_msgs.msg as visualization_msgs
+from geometry_msgs.msg import Pose, Vector3, Point
+from std_msgs.msg import ColorRGBA
+import sub8_ros_tools as sub8_utils
+
+
+class RvizVisualizer(object):
+    '''Cute tool for drawing both depth and height-from-bottom in RVIZ
+    '''
+
+    def __init__(self):
+        self.rviz_pub = rospy.Publisher("visualization/projection", visualization_msgs.Marker, queue_size=3)
+
+    def draw_ray_3d(self, pix_coords, camera_model, color, frame='/stereo_front'):
+        '''Handle range data grabbed from dvl'''
+        # future: should be /base_link/dvl, no?
+        marker = self.make_ray(
+            base=np.array([0.0, 0.0, 0.0]),
+            direction=np.array(camera_model.projectPixelTo3dRay(pix_coords)),
+            length=35.0,
+            color=color,
+            frame=frame
+        )
+
+        self.rviz_pub.publish(marker)
+
+    def make_ray(self, base, direction, length, color, frame='/base_link', **kwargs):
+        '''Handle the frustration that Rviz cylinders are designated by their center, not base'''
+        marker = visualization_msgs.Marker(
+            ns='sub',
+            id=color.index(0) + 1,
+            header=sub8_utils.make_header(frame=frame),
+            type=visualization_msgs.Marker.LINE_STRIP,
+            action=visualization_msgs.Marker.ADD,
+            color=ColorRGBA(*color),
+            scale=Vector3(0.05, 0.0, 0.0),
+            points=map(lambda o: Point(*o), [base, direction * length]),
+            lifetime=rospy.Duration(),
+            **kwargs
+        )
+        return marker

--- a/simulation/sub8_gazebo/src/sub8_buoyancy.cc
+++ b/simulation/sub8_gazebo/src/sub8_buoyancy.cc
@@ -158,8 +158,8 @@ void BuoyancyPlugin::OnUpdate() {
     // link->AddTorque(angularResistance, volumeProperties.cov);
 
     if (linkFrame.pos.z < 0.0) {
-      // link->AddLinkForce(buoyancyLinkFrame, volumeProperties.cov);
-      link->AddForceAtRelativePosition(buoyancyLinkFrame, volumeProperties.cov);
+      link->AddLinkForce(buoyancyLinkFrame, volumeProperties.cov);
+      // link->AddForceAtRelativePosition(buoyancyLinkFrame, volumeProperties.cov);
 
     }
   }

--- a/simulation/sub8_gazebo/src/sub8_thrusters.cc
+++ b/simulation/sub8_gazebo/src/sub8_thrusters.cc
@@ -95,7 +95,10 @@ void ThrusterPlugin::OnUpdate() {
     // force = thrusterMap[name].direction * thrust;
   }
   // this->targetLink->AddForceAtRelativePosition(force, thrusterMap[name].position);
-  this->targetLink->AddRelativeForce(net_force);
-  this->targetLink->AddRelativeTorque(net_torque);
+  math::Pose subFrame = this->targetLink->GetWorldPose();
+  if (subFrame.pos.z < 0.0) {
+    this->targetLink->AddRelativeForce(net_force);
+    this->targetLink->AddRelativeTorque(net_torque);
+  }
 }
 }

--- a/utils/sub8_ros_tools/sub8_ros_tools/image_helpers.py
+++ b/utils/sub8_ros_tools/sub8_ros_tools/image_helpers.py
@@ -66,8 +66,13 @@ class Image_Subscriber(object):
         Assumes topic of type "sensor_msgs/Image"
         This behaves like a conventional subscriber, except handling the additional image conversion
         '''
+        if callback is None:
+            callback = lambda im: setattr(self, 'last_image', im)
+
         self.encoding = encoding
         self.camera_info = None
+        self.last_image_time = None
+        self.last_image = None
         self.im_sub = rospy.Subscriber(topic, Image, self.convert, queue_size=queue_size)
 
         root_topic, image_subtopic = path.split(topic)
@@ -100,6 +105,7 @@ class Image_Subscriber(object):
         self.camera_info = msg
 
     def convert(self, data):
+        self.last_image_time = data.header.stamp
         try:
             image = self.bridge.imgmsg_to_cv2(data, desired_encoding=self.encoding)
             self.callback(image)


### PR DESCRIPTION
Fun for the whole family, the new Particle Filter from [Cinco](https://en.wikipedia.org/wiki/List_of_Cinco_Family_products) can estimate the pose of anything you want, from roughly spherical things to exactly spherical things!
- Adds some rviz python stuff
- Logs .dae files as binary (even though they are human-readable, they aren't usefully human readable)
- Add last_image_time, as the stamp of the last image gotten to Image_Subscriber
- Add the particle filter itself
