### PR TITLE
SIM: Fix apparent regression of C3 behavior

### DIFF
--- a/simulation/sub8_gazebo/models/sub8/sub8.sdf
+++ b/simulation/sub8_gazebo/models/sub8/sub8.sdf
@@ -3,12 +3,13 @@
   <model name="sub8">
     <link name="base_link">
       <velocity_decay>
-        <linear>0.06</linear>
+        <linear>0.02</linear>
         <angular>0.06</angular>
       </velocity_decay>
 
       <inertial>
-        <mass>36.29</mass>
+        <!-- <mass>36.29</mass> -->
+        <mass>30.29</mass>
         <inertia>
           <ixx>1.18</ixx>
           <ixy>-0.003</ixy>
@@ -82,7 +83,7 @@
             <k2>0</k2>
             <k3>0</k3>
             <p1>0</p1>
-            <p2>0</p2>>
+            <p2>0</p2>
           </distortion>
         </camera>
 
@@ -93,7 +94,7 @@
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
           <frameName>stereo_front</frameName>
-          <hackBaseline>0.089</hackBaseline>\
+          <hackBaseline>0.089</hackBaseline>
           <distortionK1>0</distortionK1>
           <distortionK2>0</distortionK2>
           <distortionK3>0</distortionK3>
@@ -115,7 +116,7 @@
             <k2>0</k2>
             <k3>0</k3>
             <p1>0</p1>
-            <p2>0</p2>>
+            <p2>0</p2>
             <center>320 240</center>
           </distortion>
         </camera>
@@ -126,7 +127,7 @@
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
           <frameName>down_camera</frameName>
-          <hackBaseline>0.89</hackBaseline>\
+          <hackBaseline>0.89</hackBaseline>
           <distortionK1>0</distortionK1>
           <distortionK2>0</distortionK2>
           <distortionK3>0</distortionK3>
@@ -178,10 +179,12 @@
 
     <plugin name="sub8_buoyancy" filename="libsub8_buoyancy.so">
       <fluid_density>1000</fluid_density>
-      <drag_coefficient>20</drag_coefficient>
+      <drag_coefficient>10</drag_coefficient>
       <link name="base_link">
         <center_of_volume>0 0 0</center_of_volume>
-        <volume>0.037</volume>
+        <!-- <volume>0.037</volume> -->
+        <volume>0.032</volume>
+
       </link>
     </plugin>
 


### PR DESCRIPTION
- In the last 2 weeks, C3 stopped behaving properly with sim
- My theory:
  - We had some uncommitted local change on the Gazebo computer that made the sub more nimble

These changes make the sub less physically representative of reality (hence no changes to sub8_nocam), but c3 behaves as expected
