### PR TITLE
ML: Add actual_wrench publisher

### DIFF
--- a/command/sub8_missions/missions/data_gather.py
+++ b/command/sub8_missions/missions/data_gather.py
@@ -1,0 +1,18 @@
+from twisted.internet import defer
+from txros import util, tf
+import numpy as np
+
+
+@util.cancellableInlineCallbacks
+def run(sub):
+
+    yield sub.move.depth(0.6).go()
+    print "Executing learn pattern"
+    for k in range(2):
+        yield sub.move.down(0.2).go()
+        yield sub.move.right(0.8).go()
+        yield sub.move.up(0.2).go()
+        yield sub.move.forward(0.8).go()
+        yield sub.move.left(0.8).go()
+        yield sub.move.backward(0.8).go()
+        yield sub.yaw_right(1.5).go()

--- a/utils/sub8_ros_tools/sub8_ros_tools/msg_helpers.py
+++ b/utils/sub8_ros_tools/sub8_ros_tools/msg_helpers.py
@@ -90,6 +90,12 @@ def odometry_to_numpy(odom):
     return pose, twist, pose_covariance, twist_covariance
 
 
+def wrench_to_numpy(wrench):
+    force = rosmsg_to_numpy(wrench.force)
+    torque = rosmsg_to_numpy(wrench.torque)
+    return force, torque
+
+
 def numpy_to_point(np_vector):
     return geometry_msgs.Point(*np_vector)
 
@@ -102,6 +108,13 @@ def numpy_to_twist(linear_vel, angular_vel):
     '''TODO: Unit-test
     '''
     return geometry_msgs.Twist(linear=geometry_msgs.Vector3(*linear_vel), angular=geometry_msgs.Vector3(*angular_vel))
+
+
+def numpy_to_wrench(forcetorque):
+    return geometry_msgs.Wrench(
+        force=geometry_msgs.Vector3(*forcetorque[:3]),
+        torque=geometry_msgs.Vector3(*forcetorque[3:])
+    )
 
 
 def numpy_matrix_to_quaternion(np_matrix):
@@ -143,7 +156,6 @@ def make_wrench_stamped(force, torque, frame='/body'):
     '''Make a WrenchStamped message without all the fuss
         Frame defaults to body
     '''
-
     wrench = geometry_msgs.WrenchStamped(
         header=make_header(frame),
         wrench=geometry_msgs.Wrench(


### PR DESCRIPTION
- Publish the actual actuated wrench (/wrench is unbounded and generally insane during normal operation)
- Add a mission for gathering motion data

**Image**: A sneak preview! Blue is what the sub actually did, green is what the estimated dynamics model says it should do, red is the error

![dynamics_fitting](https://cloud.githubusercontent.com/assets/6531468/15983120/72adc9d4-2f6b-11e6-9c77-523342e2ac02.png)
