### PR TITLE
CI: fail Jenkins build if tests dont pass

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ dockerNode(image: 'uf-mil:subjugator') {
 			source ~/.mil/milrc > /dev/null 2>&1
 			source $CATKIN_DIR/devel/setup.bash > /dev/null 2>&1
 			catkin_make -C $CATKIN_DIR run_tests
+			catkin_test_results $CATKIN_DIR/build/test_results/ --verbose 
 		'''
 	}
 }


### PR DESCRIPTION
* I think this will make the Jenkins build fail of a unit test fails. Also will display good summary of what tests passed 

* Tested: does FAIL when a test fails, see build PR-222 Run 2

* Tested: still PASSES when all tests pass, see build PR-222 Run 3