### PR TITLE
ONLINE_BAGGER: Add to sub launch and kill systems

### DIFF
--- a/command/sub8_alarm/alarm_handlers/kill.py
+++ b/command/sub8_alarm/alarm_handlers/kill.py
@@ -1,5 +1,6 @@
 import rospy
 from ros_alarms import HandlerBase
+from mil_msgs.srv import BaggerCommands
 
 class Kill(HandlerBase):
     alarm_name = 'kill'
@@ -8,12 +9,21 @@ class Kill(HandlerBase):
     def __init__(self):
         self._killed = False
         self._last_mission_killed = False
+        self.bagging_server = rospy.ServiceProxy('/online_bagger/dump', BaggerCommands)
 
     def raised(self, alarm):
         self._killed = True
+        self.bagger_dump()
 
     def cleared(self, alarm):
         self._killed = False
+
+    def bagger_dump(self):
+        """Call online_bagger/dump service"""
+        try:
+            bag_status = self.bagging_server(bag_name='kill_bag', bag_time=0)
+        except rospy.ServiceException, e:
+            print "/online_bagger service failed: %s" %e
 
     def meta_predicate(self, meta_alarm, sub_alarms):
         ignore = []

--- a/command/sub8_alarm/alarm_handlers/kill.py
+++ b/command/sub8_alarm/alarm_handlers/kill.py
@@ -20,8 +20,13 @@ class Kill(HandlerBase):
 
     def bagger_dump(self):
         """Call online_bagger/dump service"""
+        camera = '/camera/front/left/camera_info /camera/front/left/image_raw '
+        navigation = '/wrench /wrench_actual /c3_trajectory_generator/trajectory_v /c3_trajectory_generator/waypoint /trajectory '
+        controller = '/pd_out /rise_6dof/parameter_descriptions /rise_6dof/parameter_updates '
+        blueview = '/blueview_driver/ranges /blueview_driver/image_color'
+        kill_topics = camera + navigation + controller + blueview
         try:
-            bag_status = self.bagging_server(bag_name='kill_bag', bag_time=60)
+            bag_status = self.bagging_server(bag_name='kill_bag', bag_time=60, topics=kill_topics)
         except rospy.ServiceException, e:
             print "/online_bagger service failed: %s" %e
 

--- a/command/sub8_alarm/alarm_handlers/kill.py
+++ b/command/sub8_alarm/alarm_handlers/kill.py
@@ -21,7 +21,7 @@ class Kill(HandlerBase):
     def bagger_dump(self):
         """Call online_bagger/dump service"""
         try:
-            bag_status = self.bagging_server(bag_name='kill_bag', bag_time=0)
+            bag_status = self.bagging_server(bag_name='kill_bag', bag_time=60)
         except rospy.ServiceException, e:
             print "/online_bagger service failed: %s" %e
 

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -14,3 +14,8 @@ stream_time: 60  # seconds
 
 # sets bag package path, default to home/user/bags/current-date
 # bag_package_path : "home/sub8/mil_ws/bags"
+
+# Bool parameter that determines if current date is appended to bag directory
+# for example defaults to: "home/user/bags/current-date" when True
+# else bag directory goes to: "home/user/bags when False
+dated_folder: True

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -1,0 +1,15 @@
+# list an arbitrary set of topics to  subscribe to and stream:
+
+stream_time: 10  # seconds
+
+topics: [["/odom",                    300] ,
+         ["/absodom",                 300],
+         ["/stereo/left/camera_info"     ],
+         ["/stereo/left/image_raw",    20],
+         ["/stereo/right/camera_info", 20],
+         ["/stereo/right/image_raw",   20], 
+         ["/velodyne_points",         300],
+         ["/ooka",                    100]]
+
+# comment out if default home/user/online_bagger is desired
+# bag_package_path: ''  

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -6,10 +6,11 @@ stream_time: 60  # seconds
 
 # potential parameters
 
-# determines how frequently unavailable topics are resubscribed to:
-resubscriber_period : 3.0 # seconds
+# determines how frequently unavailable topics are resubscribed to defaults to 3.0 seconds:
+# resubscribe_period : 3.0 # seconds
 
-# adds additional topics to stream, also overrides default stream time
+# adds additional topics to stream, or overrides default stream time on specific topics, leave blank
+# to bag MIL bag script environmental variables only
 # topics : [["/odom", 20], ["/absodom", 20]]
 
 # sets bag package path, default to home/user/bags/current-date

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -1,6 +1,5 @@
 # list an arbitrary set of topics to  subscribe to and stream:
-# over write default stream time on specific topics in this config
-# 
+# overwrite default stream time on specific topics in this config
 
 stream_time: 60  # seconds
 

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -1,12 +1,16 @@
 # list an arbitrary set of topics to  subscribe to and stream:
+# over write default stream time on specific topics in this config
+# 
 
 stream_time: 60  # seconds
 
-topics: [["/odom",                          ],
-         ["/absodom",                       ],
-         ["/stereo/right/camera_info",      ],
-         ["/stereo/right/image_raw",        ],
-         ["/blueview_driver/ranges",        ],
-         ["/blueview_driver/image_color",   ], 
-         ["/ooka",                          ]]
+# potential parameters
 
+# determines how frequently unavailable topics are resubscribed to:
+# resubscriber_period : 5.0 # seconds
+
+# adds additional topics to stream, also overrides default stream time
+# topics : [["/odom", 20], ["/absodom", 20]]
+
+# sets bag package path, default to home/user/bags/current-date
+# bag_package_path : "home/sub8/bags"

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -1,15 +1,12 @@
 # list an arbitrary set of topics to  subscribe to and stream:
 
-stream_time: 10  # seconds
+stream_time: 60  # seconds
 
-topics: [["/odom",                    300] ,
-         ["/absodom",                 300],
-         ["/stereo/left/camera_info"     ],
-         ["/stereo/left/image_raw",    20],
-         ["/stereo/right/camera_info", 20],
-         ["/stereo/right/image_raw",   20], 
-         ["/velodyne_points",         300],
-         ["/ooka",                    100]]
+topics: [["/odom",                          ],
+         ["/absodom",                       ],
+         ["/stereo/right/camera_info",      ],
+         ["/stereo/right/image_raw",        ],
+         ["/blueview_driver/ranges",        ],
+         ["/blueview_driver/image_color",   ], 
+         ["/ooka",                          ]]
 
-# comment out if default home/user/online_bagger is desired
-# bag_package_path: ''  

--- a/command/sub8_launch/config/online_bagger.yaml
+++ b/command/sub8_launch/config/online_bagger.yaml
@@ -7,10 +7,10 @@ stream_time: 60  # seconds
 # potential parameters
 
 # determines how frequently unavailable topics are resubscribed to:
-# resubscriber_period : 5.0 # seconds
+resubscriber_period : 3.0 # seconds
 
 # adds additional topics to stream, also overrides default stream time
 # topics : [["/odom", 20], ["/absodom", 20]]
 
 # sets bag package path, default to home/user/bags/current-date
-# bag_package_path : "home/sub8/bags"
+# bag_package_path : "home/sub8/mil_ws/bags"

--- a/command/sub8_launch/launch/sub8.launch
+++ b/command/sub8_launch/launch/sub8.launch
@@ -15,6 +15,7 @@
   <include file="$(find sub8_launch)/launch/subsystems/odometry.launch"/>
   <include file="$(find sub8_launch)/launch/subsystems/thrusters.launch"/>
   <include file="$(find sub8_launch)/launch/subsystems/rise.launch"/>
+  <include file="$(find sub8_launch)/launch/subsystems/online_bagger.launch"/>
   <include file="$(find sub8_alarm)/launch/alarms.launch" />
 
   <!-- 

--- a/command/sub8_launch/launch/subsystems/online_bagger.launch
+++ b/command/sub8_launch/launch/subsystems/online_bagger.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node pkg="mil_tools" type="online_bagger.py" name="online_bagger" output="screen"/>
+    <rosparam file="$(find sub8_launch)/config/online_bagger.yaml" command="load" ns="online_bagger"/>
+</launch>

--- a/command/sub8_launch/launch/subsystems/online_bagger.launch
+++ b/command/sub8_launch/launch/subsystems/online_bagger.launch
@@ -1,4 +1,4 @@
 <launch>
     <node pkg="mil_tools" type="online_bagger.py" name="online_bagger" output="screen"/>
-    <rosparam file="$(find sub8_launch)/config/online_bagger.yaml" command="load" ns="online_bagger"/>
+    <rosparam file="$(find sub8_launch)/config/online_bagger.yaml" command="load" ns="onine_bagger"/>
 </launch>


### PR DESCRIPTION
Oooooweeeee! Online_bagger has been added to the launch and kill systems for the sub. (launches with the sub and calls the service dump on kill)

Whenever 'araise kill' is called, the current message set is dumped to a bag called 'kill_bag' (see PR in mil_common). It will repeatedly get written over with the name 'kill_bag.bag' to prevent having too many kill bags (this makes it our responsibility to rename bags we care about). I can switch back to the default bag name (current date and time) if we reach some sort of consensus on it. 

I also updated the yaml to bag one camera (right) and the blueview images and ranges by default. (Again, can be changed)