### PR TITLE
PATH MARKER: Use kalman filter to reduce pose estimate noise

### DIFF
--- a/command/sub8_missions/missions/align_path_marker.py
+++ b/command/sub8_missions/missions/align_path_marker.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import genpy
 import tf
+import numpy as np
 from twisted.internet import defer
 from txros import util
 from sub8 import Searcher
@@ -10,39 +11,57 @@ from mil_misc_tools import text_effects
 import numpy as np
 
 SEARCH_DEPTH = .65
+SEARCH_RADIUS_METERS = 1.0
 TIMEOUT_SECONDS = 60
+DO_PATTERN=True
+SPEED = 0.5
 MISSION="Align Path Marker"
+
+forward_vec = np.array([1, 0, 0, 0])
 @util.cancellableInlineCallbacks
 def run(sub):
-    print_info = text_effects.FprintFactory(title=MISSION)
-    print_bad = text_effects.FprintFactory(title=MISSION, msg_color="red")
-    print_good = text_effects.FprintFactory(title=MISSION, msg_color="green")
-    print_info.fprint("STARTING")
+    print_info = text_effects.FprintFactory(title=MISSION).fprint
+    print_bad = text_effects.FprintFactory(title=MISSION, msg_color="red").fprint
+    print_good = text_effects.FprintFactory(title=MISSION, msg_color="green").fprint
+    print_info("STARTING")
 
     # Wait for vision services, enable perception
-    print_info.fprint("ACTIVATING PERCEPTION SERVICE")
+    print_info("ACTIVATING PERCEPTION SERVICE")
     sub.vision_proxies.path_marker.start()
 
     pattern = []
-    #pattern = [sub.move.right(1), sub.move.forward(1), sub.move.left(1), sub.move.backward(1),
-     #          sub.move.right(2), sub.move.forward(2), sub.move.left(2), sub.move.backward(2)]
+    if DO_PATTERN:
+        pattern = [sub.move.right(SEARCH_RADIUS_METERS), sub.move.forward(SEARCH_RADIUS_METERS),
+                   sub.move.left(SEARCH_RADIUS_METERS), sub.move.backward(SEARCH_RADIUS_METERS),
+                   sub.move.right(2.0*SEARCH_RADIUS_METERS), sub.move.forward(2.0*SEARCH_RADIUS_METERS),
+                   sub.move.left(2.0*SEARCH_RADIUS_METERS), sub.move.backward(2.0*SEARCH_RADIUS_METERS)]
     s = Searcher(sub, sub.vision_proxies.path_marker.get_pose, pattern)
     resp = None
-    print_info.fprint("RUNNING SEARCH PATTERN")
+    print_info("RUNNING SEARCH PATTERN")
     resp = yield s.start_search(loop=False, timeout=TIMEOUT_SECONDS, spotings_req=1)
 
     if resp is None or not resp.found:
-        print_bad.fprint("MARKER NOT FOUND")
+        print_bad("MARKER NOT FOUND")
         defer.returnValue(None)
-    
-    print_good.fprint("PATH MARKER POSE FOUND")
+
+    print_good("PATH MARKER POSE FOUND")
     assert(resp.pose.header.frame_id == "/map")
-    move = sub.move.set_orientation(rosmsg_to_numpy(resp.pose.pose.orientation)).zero_roll_and_pitch()
+
+    move = sub.move
     position = rosmsg_to_numpy(resp.pose.pose.position)
-    position[2] = move._pose.position[2]
-    move = move.set_position(position)
-    print_info.fprint("MOVING TO MARKER POSE")
-    yield move.go(speed=0.2)
-    print_good.fprint("ALIGNED TO PATH MARKER, DONE!")
+    position[2] = move._pose.position[2] # Leave Z alone!
+    orientation = rosmsg_to_numpy(resp.pose.pose.orientation)
+
+    move = move.set_position(position).set_orientation(orientation).zero_roll_and_pitch()
+
+    # Ensure SubjuGator continues to face same general direction as before (doesn't go in opposite direction)
+    odom_forward = tf.transformations.quaternion_matrix(sub.move._pose.orientation).dot(forward_vec)
+    marker_forward = tf.transformations.quaternion_matrix(orientation).dot(forward_vec)
+    if np.sign(odom_forward[0]) != np.sign(marker_forward[0]):
+        move = move.yaw_right(np.pi)
+
+    print_info("MOVING TO MARKER AT {}".format(move._pose.position))
+    yield move.go(speed=SPEED)
+    print_good("ALIGNED TO PATH MARKER. MOVE FORWARD TO NEXT CHALLENGE!")
     sub.vision_proxies.path_marker.stop()
     defer.returnValue(True)

--- a/command/sub8_missions/missions/align_path_marker.py
+++ b/command/sub8_missions/missions/align_path_marker.py
@@ -14,6 +14,7 @@ SEARCH_DEPTH = .65
 SEARCH_RADIUS_METERS = 1.0
 TIMEOUT_SECONDS = 60
 DO_PATTERN=True
+FACE_FORWARD=True
 SPEED = 0.5
 MISSION="Align Path Marker"
 
@@ -31,10 +32,17 @@ def run(sub):
 
     pattern = []
     if DO_PATTERN:
-        pattern = [sub.move.right(SEARCH_RADIUS_METERS), sub.move.forward(SEARCH_RADIUS_METERS),
-                   sub.move.left(SEARCH_RADIUS_METERS), sub.move.backward(SEARCH_RADIUS_METERS),
-                   sub.move.right(2.0*SEARCH_RADIUS_METERS), sub.move.forward(2.0*SEARCH_RADIUS_METERS),
-                   sub.move.left(2.0*SEARCH_RADIUS_METERS), sub.move.backward(2.0*SEARCH_RADIUS_METERS)]
+        start = sub.move.zero_roll_and_pitch()
+        r = SEARCH_RADIUS_METERS
+        pattern = [start.zero_roll_and_pitch(),
+                   start.right(r),
+                   start.forward(r),
+                   start.left(r),
+                   start.backward(r),
+                   start.right(2*r),
+                   start.forward(2*r),
+                   start.left(2*r),
+                   start.backward(2*r)]
     s = Searcher(sub, sub.vision_proxies.path_marker.get_pose, pattern)
     resp = None
     print_info("RUNNING SEARCH PATTERN")
@@ -57,7 +65,7 @@ def run(sub):
     # Ensure SubjuGator continues to face same general direction as before (doesn't go in opposite direction)
     odom_forward = tf.transformations.quaternion_matrix(sub.move._pose.orientation).dot(forward_vec)
     marker_forward = tf.transformations.quaternion_matrix(orientation).dot(forward_vec)
-    if np.sign(odom_forward[0]) != np.sign(marker_forward[0]):
+    if FACE_FORWARD and np.sign(odom_forward[0]) != np.sign(marker_forward[0]):
         move = move.yaw_right(np.pi)
 
     print_info("MOVING TO MARKER AT {}".format(move._pose.position))

--- a/perception/sub8_perception/nodes/path_marker_finder.py
+++ b/perception/sub8_perception/nodes/path_marker_finder.py
@@ -32,8 +32,11 @@ class PathMarkerFinder():
       * checking # of sides in appox polygon
       * checking ratio of length/width close to known model
     * estimates 3D pose using cv2.solvePnP with known object demensions and camera model
+    * Use translation vector from PnP and direction vector from 2d contour for pose
+    * Transform this frames pose into /map frame
+    * Plug this frames pose in /map into a kalman filter to reduce noise
     
-    TODO: Implement Kalman filter to smooth pose estimate / eliminate outliers
+    TODO: Allow for two path markers identifed at once, both filtered through its own KF
     """
     # Model of four corners of path marker, centered around 0 in meters
     LENGTH = 0.6096 # Longer side of path marker in meters
@@ -297,7 +300,7 @@ class PathMarkerFinder():
         map_vec3 = None
         map_ps = None
 
-        # Transform pose estimate to map framr
+        # Transform pose estimate to map frame
         try:
             self.tf_listener.waitForTransform('/map', ps.header.frame_id, ps.header.stamp, rospy.Duration(0.05))
             map_ps = self.tf_listener.transformPoint('/map', ps)
@@ -326,9 +329,8 @@ class PathMarkerFinder():
 
     def _get_pose_2D(self, r):
         '''
-        Given a sorted 4 sided polygon, stores the centriod and angle
+        Given a sorted 4 sided polygon, stores the centroid and angle
         for the next service call to get 2dpose.
-        returns False if dx of polygon is 0, otherwise True
         '''
         top_center = (r[1]+r[0])/2.0
         bot_center = (r[2]+r[3])/2.0

--- a/perception/sub8_perception/nodes/path_marker_finder.py
+++ b/perception/sub8_perception/nodes/path_marker_finder.py
@@ -38,6 +38,11 @@ class PathMarkerFinder():
     # Model of four corners of path marker, centered around 0 in meters
     LENGTH = 0.6096 # Longer side of path marker in meters
     WIDTH = 0.0762 # Shorter Side
+
+    # Demensions of the prop we made for testing
+    # LENGTH = 0.4572
+    # WIDTH = 0.05715
+
     PATH_MARKER = np.array([[LENGTH,  -WIDTH, 0],
                             [LENGTH,  WIDTH,  0],
                             [-LENGTH,  WIDTH, 0],

--- a/perception/sub8_perception/test/path_marker.test
+++ b/perception/sub8_perception/test/path_marker.test
@@ -1,6 +1,7 @@
 <launch>
-  <node pkg="sub8_perception" type="path_marker_finder.py" name="path_marker_finder">
+  <node pkg="sub8_perception" type="path_marker_finder.py" name="path_marker_finder" output="log">
     <rosparam file="$(find sub8_launch)/config/path_marker_finder.yaml" command="load" />
+    <param name="do_3D" value="False" />
   </node>
   <test test-name="path_marker_test" pkg="sub8_perception" type="test_path_marker.py">
     <param name="pool_path2" value="$(find sub8_perception)/tests/follow_orange_pipes/pool_path2.bag" />

--- a/perception/sub8_perception/test/test_path_marker.py
+++ b/perception/sub8_perception/test/test_path_marker.py
@@ -34,8 +34,11 @@ class TestPathMarker(unittest.TestCase):
     def get_ideal_response(self, pts):
         pts = np.array(pts)
         res = VisionRequest2DResponse()
-        middle = pts[0]+(pts[1]-pts[0])/2
-        theta = np.arctan( (float(pts[1][1])-pts[0][1]) / (pts[1][0] - pts[0][0]) )
+        middle = pts[0]+(pts[1]-pts[0])/2.0
+        vector = pts[1] - pts[0]
+        if vector[0] < 0.0:
+            vector[0] = -vector[0]
+        theta = np.arctan2(vector[1], vector[0])
         res.pose.x = middle[0]
         res.pose.y = middle[1]
         res.pose.theta = theta
@@ -74,7 +77,7 @@ class TestPathMarker(unittest.TestCase):
         err = np.linalg.norm(res_xy-correct_xy)
         msg="Marker pose (x,y) too much error Res={} Correct={} Error={}".format(res_xy, correct_xy, err)
         self.assertLess(err, 
-                        10.0,
+                        20.0, # A little bit of tolerance given in precise ground truth. Will lower when new label system
                         msg=msg)
         #5 degrees error accepted
         theta_err = abs(np.arctan2(np.sin(res.pose.theta-correct.pose.theta), np.cos(res.pose.theta-correct.pose.theta)))

--- a/perception/sub8_perception/test/test_path_marker.py
+++ b/perception/sub8_perception/test/test_path_marker.py
@@ -66,6 +66,8 @@ class TestPathMarker(unittest.TestCase):
             if topic == self.info_topic:
                 self.cam_info_pub.publish(msg)
         res = self.service(VisionRequest2DRequest())
+        msg = "Marker not found after playing bag"
+        self.assertTrue(res.found, msg=msg)
         # 10 pixel error accepted
         res_xy = np.array([res.pose.x, res.pose.y])
         correct_xy = np.array([correct.pose.x, correct.pose.y])


### PR DESCRIPTION
* Use kalman filter for smoothing noise in path marker vision. Seems to work well in testing. Should ensure we don't accidentally try to move to some visual artifact that looks like a path marker
* Enable down camera in camera.launch, restore calibration file from a while back (might not be good)