### PR TITLE
THRUSTERS: fix timing dependent thruster detection

### DIFF
--- a/drivers/sub8_videoray_m5_thruster/sub8_thruster_comm/thruster_comm.py
+++ b/drivers/sub8_videoray_m5_thruster/sub8_thruster_comm/thruster_comm.py
@@ -10,8 +10,7 @@ import rospy
 
 class ThrusterPort(object):
     _baud_rate = 115200
-    _timeout = 0.01  # How long to wait for a serial response
-    _max_motor_id = 100  # Max motor ID for which to verify the existence
+    _timeout = 0.1  # How long to wait for a serial response
 
     def __init__(self, port_info, thruster_definitions):
         '''Communicate on a single port with some thrusters
@@ -37,10 +36,6 @@ class ThrusterPort(object):
             - The thrusters automatically shut down if they do not recieve a
              command for ~2 seconds
 
-            - Potential source of problem for future users:
-                If the sub is ever using more than 100 thrusters, and you find that the Sub isn't finding them,
-                it is because of max_motor_id
-            - This might also trigger timeout errors in the thruster_driver node spin-up
         TODO:
             --> 0x88, 0x8c: Set slew-rate up and down to something tiny
             --> Send messages without getting status
@@ -52,17 +47,12 @@ class ThrusterPort(object):
         self.thruster_dict = {} # holds the motor_ids of all the thrusters that were supposed
                                 # to be here and were actually found
 
-        # Determine which thrusters are really responding
-        self.motor_ids_on_port = []
-        for guess_id in range(self._max_motor_id):  # search a subset of possible motor ids
-            have_thruster = self.check_for_thruster(guess_id)
-            if have_thruster:
-                self.motor_ids_on_port.append(guess_id)
-
         # Load thruster configurations and check if the requested thruster exists on this port
         self.missing_thrusters = []
         for thruster_name in port_info['thruster_names']:
             try:
+                # Note: will only try to detect thrusters as listed in the layout. That means 
+                # that if a thruster is connected to the wrong port, IT WILL NOT BE FOUND.
                 self.load_thruster_config(thruster_name, thruster_definitions)
             except IOError:
                 self.missing_thrusters.append(thruster_name)
@@ -80,12 +70,12 @@ class ThrusterPort(object):
     def load_thruster_config(self, thruster_name, thruster_definitions):
         '''Loads the motor_id from the config file if the thruster was found'''
         # Get our humungous error string ready
-        errstr = "Could not find motor_id {} (Called {}) on port {}; existing ids are {}".format(
-            thruster_definitions[thruster_name]['motor_id'], thruster_name, self.port_name, self.motor_ids_on_port)
+        errstr = "Could not get a response from motor_id {} (Called {}) on port {}".format(
+            thruster_definitions[thruster_name]['motor_id'], thruster_name, self.port_name)
 
         # Check if we can actually find the thruster on this port
         motor_id = int(thruster_definitions[thruster_name]["motor_id"])
-        if not motor_id in self.motor_ids_on_port:
+        if not self.check_for_thruster(motor_id):
             rospy.logerr(errstr)
             raise(IOError(errstr))
         self.thruster_dict[thruster_name] = motor_id
@@ -206,12 +196,13 @@ class ThrusterPort(object):
 
     def check_for_thruster(self, motor_id):
         self.send_poll_msg(motor_id)
-        response_bytearray = self.port.read(Const.thrust_response_length)
-        if len(response_bytearray) != Const.thrust_response_length:
+        response_dict = self.read_status()
+        if response_dict is None:
             return False
         else:
             # We have the thruster!
-            return True
+            found = response_dict['response_node_id'] == motor_id
+            return found
 
     def read_status(self):
         response_bytearray = self.port.read(Const.thrust_response_length)

--- a/drivers/sub8_videoray_m5_thruster/sub8_thruster_comm/thruster_comm.py
+++ b/drivers/sub8_videoray_m5_thruster/sub8_thruster_comm/thruster_comm.py
@@ -204,6 +204,23 @@ class ThrusterPort(object):
             found = response_dict['response_node_id'] == motor_id
             return found
 
+    def get_motor_ids_on_port(self, start_id, end_id):
+        '''
+        Polls for thrusters with motor ids within provided range and returns
+        a list with the ids of thrusters that responded
+        Also returns the average time between sending the poll packet and
+        receiving a response for all detected thrusters
+        '''
+        to_check = range(start_id, end_id + 1)
+        found_ids = []
+        turnaround_times = []
+        for i in to_check:
+            t0 = time.time()
+            if self.check_for_thruster(i):
+                found_ids.append(i)
+                turnaround_times.append(time.time() - t0)
+        return found_ids, np.mean(turnaround_times)
+
     def read_status(self):
         response_bytearray = self.port.read(Const.thrust_response_length)
         # We should always get $Const.thrust_response_length bytes, if we don't

--- a/utils/sub8_diagnostics/scripts/thruster_spinner.py
+++ b/utils/sub8_diagnostics/scripts/thruster_spinner.py
@@ -31,7 +31,10 @@ def ports_from_layout(layout):
             for name in thruster_names:
                 port_dict[name] = thruster_port
 
-            msg += "\n\tMotor id's on port: {}".format(thruster_port.motor_ids_on_port)
+            msg += "\n\tMotor id's on port: {}{}{}".format(
+                Colors.bold + Colors.blue,
+                np.sort([x[1] for x in thruster_port.thruster_dict.items()]).tolist(),
+                Colors.reset)
             fprint(msg)
 
         except serial.serialutil.SerialException as e:

--- a/utils/sub8_diagnostics/scripts/thruster_spinner.py
+++ b/utils/sub8_diagnostics/scripts/thruster_spinner.py
@@ -64,7 +64,9 @@ Welcome to David's thruster_spin_test tool.
 '''
 fprint(usage_msg)
 
-thrust = 0.5  # Normalized thrust in [0, 1]
+thrust = 0.0  # Normalized thrust in [-1, 1]
+step = 0.05
+
 key = None
 
 def command_thrusters(timer_event):
@@ -90,12 +92,12 @@ while not rospy.is_shutdown():
         if get_ch() == '[':        # Got an arrow key
             arrow_type = get_ch()
             if arrow_type == 'A':  # UP key
-                thrust = thrust + 0.1
+                thrust = thrust + step
             if arrow_type == 'B':  # DOWN key
-                thrust = thrust - 0.1
+                thrust = thrust - step
         else:                      # Got other ESC sequence
             continue
-        thrust = np.clip(thrust, 0.0, 1.0)
+        thrust = np.clip(thrust, -1.0, 1.0)
         fprint("Thrust: {}".format(thrust))
         continue
 


### PR DESCRIPTION
### Thruster Comms
* Increase the serial port timeout from 0.01 s to 0.1 s.
* Parse the response to poll packets to confirm that the response packet
  is actually from the thruster we believe it to be.
* Instead of checking for about 100 thruster ID's on each port, only check the
  ones that have been declared on the thruster layout.
### ThrusterSpinner
* Changed allowable effort range to [-1, 1] so we can spin in both directions
* Added a thruster discovery mode to the thruster spinner utility so that we can
  find out what thrusters are plugged into a port even if they were not declared
  on the thruster_layout.yaml
* Added reporting average packet turnaround time to discovery mode.
**_Proof:_** 
I swapped the connectors for the BR and FR ports on the back of the sub. I ran
the thruster spinner utility and was told that half of the thrusters were missing.
Then I entered discovery mode by pressing 'C' and was able to find the missing
thrusters.
![image](https://cloud.githubusercontent.com/assets/8714358/25777694/c87f6502-32b2-11e7-958f-53758d3f4f9c.png)

Resolves #195 