### PR TITLE
BLUEVIEW: hotfix for launch file typo #OneLineDiff

### DIFF
--- a/command/sub8_launch/launch/subsystems/blueview.launch
+++ b/command/sub8_launch/launch/subsystems/blueview.launch
@@ -16,7 +16,7 @@
             range_profile_intensity_threshold: 2000
             noise_threshold: 0.2
         </rosparam>
-        <param name="color/map_file" value="$(find bvtsdkpkg)/colormaps/jet.cmap" />
+        <param name="color/map_file" value="$(find mil_blueview_driver)/bvtsdk/colormaps/jet.cmap" />
     </node>
 </launch>
 


### PR DESCRIPTION
* one line change to fix blueview launch file, separated from #229 so this can be fixed while I'm still working on path marker