### PR TITLE
SCRIPTS: switch bag variable to image_rect_color, add fps alias

### DIFF
--- a/scripts/bagging_variables.sh
+++ b/scripts/bagging_variables.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# This script will be sourced by the bmux command and the variables will be
-# used by the bag command. It is imperative that each variable is in the bag_*
-# namespace and contains a space diliniated list of ROS topics. The only two
-# exceptions to this rule are the BAG_ALWAYS and BAG_DIR variables.
+# This script will be sourced by the bag command as a configuration file. It is
+# imperative that each variable is in the bag_* namespace and contains a space
+# deliniated list of ROS topics. The only two exceptions to this rule are the
+# BAG_ALWAYS and BAG_DIR variables.
 
 
 # Define topics that should be in every bag
@@ -13,11 +13,15 @@ export BAG_ALWAYS="/odom /absodom /clock /tf /tf_static"
 export BAG_DIR=~/bags
 
 
+# Define the type of image to use for camera topics
+export CAM_SUFFIX="image_rect_color"
+
+
 # Topic variables that can be used from the bag command
-export bag_front_left_cam="/camera/front/left/camera_info /camera/front/left/image_raw"
-export bag_front_right_cam="/camera/front/right/camera_info /camera/front/right/image_raw"
+export bag_front_left_cam="/camera/front/left/camera_info /camera/front/left/$CAM_SUFFIX"
+export bag_front_right_cam="/camera/front/right/camera_info /camera/front/right/$CAM_SUFFIX"
 export bag_front_cams="$bag_front_left_cam $bag_front_right_cam"
-export bag_down_cam="/camera/down/left/camera_info /camera/down/left/image_raw"
+export bag_down_cam="/camera/down/left/camera_info /camera/down/left/$CAM_SUFFIX"
 export bag_blueview_ranges="/blueview_driver/ranges"
 export bag_blueview_color="/blueview_driver/image_color"
 export bag_blueview_mono="/blueview_driver/image_mono"

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -17,3 +17,6 @@ alias sshsub="ssh sub8@${HOSTNAMES[0]} -Y"
 # Missions
 alias subm="rosrun sub8_missions run_mission"
 alias subc="rosrun sub8_missions move_command"
+
+# Cameras
+alias subfps="rostopic hz $bag_front_cams $bag_down_cam"


### PR DESCRIPTION
We found with Navigator that it's more convientent to have image_rect_color in bags since all perception nodes (should) use it instead of image_raw. This makes it easier to test without having to run image_proc, and you could pottentialy still unrectify back to image_raw if needed. So this switches the bag variables to use image_rect_color.

I also added the alias I was using at testing today to see if the cameras were up. It just runs rostopic hz on the camera topics so we can know which ones are up and what their framerates are. Useful for diagnostics.