### PR TITLE
THRUSTERS: raise alarm on fatal thruster configuration

### DIFF
--- a/drivers/sub8_videoray_m5_thruster/nodes/thruster_driver.py
+++ b/drivers/sub8_videoray_m5_thruster/nodes/thruster_driver.py
@@ -221,38 +221,6 @@ class ThrusterDriver(object):
                 rospy.logwarn("Thruster {} has come back online".format(name))
                 self.alert_thruster_unloss(name)
 
-    def alert_thruster_unloss(self, thruster_name):
-        if thruster_name in self.failed_thrusters:
-            self.failed_thrusters.remove(thruster_name)
-
-        if len(self.failed_thrusters) == 0:
-            self.thruster_out_alarm.clear_alarm(parameters={"clear_all"})
-        else:
-            severity = 3 if len(self.failed_thrusters) <= rospy.get_param("thruster_loss_limit", 2) else 5
-            rospy.logerr(self.failed_thrusters)
-            self.thruster_out_alarm.raise_alarm(
-                parameters={
-                    'thruster_names': self.failed_thrusters,
-                },
-                severity=severity
-            )
-
-    def alert_thruster_loss(self, thruster_name, last_update):
-        if thruster_name not in self.failed_thrusters:
-            self.failed_thrusters.append(thruster_name)
-
-        # Severity rises to 5 if too many thrusters are out
-        severity = 3 if len(self.failed_thrusters) <= rospy.get_param("thruster_loss_limit", 2) else 5
-        rospy.logerr(self.failed_thrusters)
-        self.thruster_out_alarm.raise_alarm(
-            problem_description='Thruster {} has failed'.format(thruster_name),
-            parameters={
-                'thruster_names': self.failed_thrusters,
-                'last_update': last_update
-            },
-            severity=severity
-        )
-
     def fail_thruster(self, srv):
         self.alert_thruster_loss(srv.thruster_name, None)
         return FailThrusterResponse()
@@ -342,33 +310,34 @@ class ThrusterDriver(object):
             self.failed_thrusters.remove(thruster_name)
         if len(self.failed_thrusters) == 0:
             self.thruster_out_alarm.clear_alarm(parameters={"clear_all"})
-        else:
-            rospy.wait_for_service('update_thruster_layout')
-            try:
-                update = rospy.ServiceProxy('update_thruster_layout', UpdateThrusterLayout)
-                rospy.wait_for_service('b_matrix')
-                try:
-                    B = rospy.ServiceProxy('b_matrix', BMatrix)
-                    B = np.asmatrix(B)
-                    if (np.linalg.matrix_rank(B) < 6):
-                        self.thruster_out_alarm.raise_alarm(
-                            parameters={
-                                'thruster_names': self.failed_thrusters + "B MATRIX IS SINGULAR",
-                            },
-                            severity=5
-                        )
-                except rospy.ServiceException, e:
-                    print "Service call failed: %s"%e
-            except rospy.ServiceException, e:
-                print "Service call failed: %s"%e
-            severity = 3 if len(self.failed_thrusters) <= rospy.get_param("thruster_loss_limit", 2) else 5
-            rospy.logerr(self.failed_thrusters)
-            self.thruster_out_alarm.raise_alarm(
-                parameters={
-                    'thruster_names': self.failed_thrusters,
-                },
-                severity=severity
-            )
+        try:
+            update = rospy.ServiceProxy('update_thruster_layout', UpdateThrusterLayout)
+            update()
+            get_b = rospy.ServiceProxy('b_matrix', BMatrix)
+            b_proxy = get_b()
+            B = np.asmatrix(b_proxy.B).reshape(6, -1)
+            if (np.linalg.matrix_rank(B) < 6):
+                self.thruster_out_alarm.raise_alarm(
+                    parameters={
+                        'thruster_names': self.failed_thrusters,
+                        'issue': "B MATRIX IS SINGULAR",
+                    },
+                    severity=5
+                )
+
+        except rospy.ServiceException, e:
+            rospy.logerr("Service call failed: %s"%e)
+        # Severity rises to 5 if too many thrusters are out
+        severity = 3 if len(self.failed_thrusters) <= rospy.get_param("thruster_loss_limit", 2) else 5
+        rospy.logerr(self.failed_thrusters)
+        self.thruster_out_alarm.raise_alarm(
+            problem_description='Thruster {} has failed'.format(thruster_name),
+            parameters={
+                'thruster_names': self.failed_thrusters,
+                'last_update': last_update
+            },
+            severity=severity
+        )
 
     def alert_thruster_loss(self, thruster_name, last_update):
         if thruster_name not in self.failed_thrusters:
@@ -376,22 +345,20 @@ class ThrusterDriver(object):
         try:
             update = rospy.ServiceProxy('update_thruster_layout', UpdateThrusterLayout)
             update()
-            try:
-                get_b = rospy.ServiceProxy('b_matrix', BMatrix)
-                b_response = get_b()
-                B = np.asmatrix(b_response.B).reshape(6, -1)
-                if (np.linalg.matrix_rank(B) < 6):
-                    self.thruster_out_alarm.raise_alarm(
-                        parameters={
-                            'thruster_names': self.failed_thrusters,
-                            'issue': "B MATRIX IS SINGULAR",
-                        },
-                        severity=5
-                    )
-            except rospy.ServiceException, e:
-                print "Service call failed: %s"%e
+            get_b = rospy.ServiceProxy('b_matrix', BMatrix)
+            b_proxy = get_b()
+            B = np.asmatrix(b_proxy.B).reshape(6, -1)
+            if (np.linalg.matrix_rank(B) < 6):
+                self.thruster_out_alarm.raise_alarm(
+                    parameters={
+                        'thruster_names': self.failed_thrusters,
+                        'issue': "B MATRIX IS SINGULAR",
+                    },
+                    severity=5
+                )
+
         except rospy.ServiceException, e:
-            print "Service call failed: %s"%e
+            rospy.logerr("Service call failed: %s"%e)
         # Severity rises to 5 if too many thrusters are out
         severity = 3 if len(self.failed_thrusters) <= rospy.get_param("thruster_loss_limit", 2) else 5
         rospy.logerr(self.failed_thrusters)

--- a/gnc/sub8_thruster_mapper/nodes/mapper.py
+++ b/gnc/sub8_thruster_mapper/nodes/mapper.py
@@ -63,10 +63,14 @@ class ThrusterMapper(object):
         self.max_thrusts = np.copy(self.default_max_thrusts)
 
         for thruster_name in self.dropped_thrusters:
-            thruster_index = self.thruster_name_map.index(thruster_name)
-            self.min_thrusts[thruster_index] = -self.min_commandable_thrust * 0.5
-            self.max_thrusts[thruster_index] = self.min_commandable_thrust * 0.5
-
+            try:
+                thruster_index = self.thruster_name_map.index(thruster_name)
+                self.min_thrusts[thruster_index] = -self.min_commandable_thrust * 0.5
+                self.max_thrusts[thruster_index] = self.min_commandable_thrust * 0.5
+            except:
+                print "Failed"
+            self.thruster_layout['thrusters'].pop(thruster_name, "None")
+        self.B = self.generate_B(self.thruster_layout)
         rospy.logwarn("Layout updated")
         return UpdateThrusterLayoutResponse()
 
@@ -123,6 +127,7 @@ class ThrusterMapper(object):
             )
             self.num_thrusters += 1
             B.append(wrench_column)
+
         return np.transpose(np.array(B))
 
     def map(self, wrench):


### PR DESCRIPTION
#252 THIS IS NOT READY FOR MERGE. I added a thruster kill for when we lose two linearly dependent thrusters. I couldn't think of a way to test it without running it on the sub and unplugging thrusters so I figured I would just post this to show what I have so far and to see if anyone had any input.