### PR TITLE
CI: Add C++ and Python formatting as build checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ dockerNode(image: 'uf-mil:subjugator') {
 		sh '''
 			source ~/.mil/milrc > /dev/null 2>&1
 			git submodule update --init --recursive
-			ln -s `pwd` $CATKIN_DIR/src/SubjuGator
+			ln -s $PWD $CATKIN_DIR/src/SubjuGator
 			git clone --recursive https://github.com/uf-mil/mil_common $CATKIN_DIR/src/mil_common
 			ln -s $MIL_CONFIG_DIR/bvtsdk $CATKIN_DIR/src/mil_common/drivers/mil_blueview_driver/bvtsdk
 		'''
@@ -21,6 +21,21 @@ dockerNode(image: 'uf-mil:subjugator') {
 			source $CATKIN_DIR/devel/setup.bash > /dev/null 2>&1
 			catkin_make -C $CATKIN_DIR run_tests
 			catkin_test_results $CATKIN_DIR/build/test_results --verbose 
+		'''
+	}
+	stage("Format") {
+		sh '''
+			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
+			wget -O ~/.clang-format https://raw.githubusercontent.com/uf-mil/installer/master/.clang-format
+			for FILE in $(find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp'); do
+				if [ ! -z "$(clang-format-3.8 -style=file -output-replacements-xml $FILE | grep '<replacement ')" ]; then
+					FILES+=( "$FILE" )
+				fi
+			done
+			if (( ${#FILES[@]} > 0 )); then
+				echo "The C++ following files are not formatted correctly: ${FILES[@]}"
+				exit 1
+			fi
 		'''
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ dockerNode(image: 'uf-mil:subjugator') {
 		sh '''
 			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
 			wget -O ~/.clang-format https://raw.githubusercontent.com/uf-mil/installer/master/.clang-format
-			for FILE in $(find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp'); do
+			for FILE in $(find -regex ".*/.*\\.\\(c\\|cc\\|cpp\\|h\\|hpp\\)$"); do
 				if [ ! -z "$(clang-format-3.8 -style=file -output-replacements-xml $FILE | grep '<replacement ')" ]; then
 					FILES+=( "$FILE" )
 				fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ dockerNode(image: 'uf-mil:subjugator') {
 	}
 	stage("Format") {
 		sh '''
-			if [[ ! -z "$(python2.7 -m flake8 --max-line-length=120 --exclude=__init__.py .)" ]]; then
+			if [[ ! -z "$(python2.7 -m flake8 --ignore E731 --max-line-length=120 --exclude=__init__.py .)" ]]; then
 				echo "The preceding Python following files are not formatted correctly"
 				exit 1
 			fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,12 @@ dockerNode(image: 'uf-mil:subjugator') {
 	}
 	stage("Format") {
 		sh '''
+			if [[ ! -z "$(python2.7 -m flake8 --max-line-length=120 --exclude=__init__.py .)" ]]; then
+				echo "The preceding Python following files are not formatted correctly"
+				exit 1
+			fi
+		'''
+		sh '''
 			source /opt/ros/kinetic/setup.bash > /dev/null 2>&1
 			wget -O ~/.clang-format https://raw.githubusercontent.com/uf-mil/installer/master/.clang-format
 			for FILE in $(find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp'); do


### PR DESCRIPTION
This adds a stage to the end of the build process that checks whether or not the new code is formatted according to our style guides. The build will fail if the files are not formatted correctly and a list of the ones that need to be changed for each language will be printed. See the [mil_common wiki](https://github.com/uf-mil/mil_common/wiki) for more information on how to automatically format code.

Have a look at [this Jenkins build](https://ci.mil.ufl.edu/jenkins/blue/organizations/jenkins/uf-mil%2FSubjuGator/detail/PR-259/4/pipeline) for this for information on what Python files need to be fixed.

Have a look at [this Jenkins build](https://ci.mil.ufl.edu/jenkins/blue/organizations/jenkins/uf-mil%2FSubjuGator/detail/PR-259/3/pipeline) for this for information on what C++ files need to be fixed. @DSsoto, this is all yours if you want it.

As each formatting pull request is merged to master, the build of this pull request should be run again by the user. Once all of the formatting checks pass, we can merge this. If you disagree with one of the formatting rules, feel free to debate it on this pull request and I will consider removing it.