### PR TITLE
TF: update down camera tf

### DIFF
--- a/command/sub8_launch/launch/tf.launch
+++ b/command/sub8_launch/launch/tf.launch
@@ -13,7 +13,7 @@
     </node>
 
     <node pkg="tf" type="static_transform_publisher" name="camera_down_broadcaster"
-      args="0.0537  0.1048 -0.2565   7.07106781e-01 -7.07106781e-01 0.0 0.0 base_link down_left_cam 100">
+      args="0.054 0.105 -0.256 1 0 0 0 base_link down_left_cam 100">
     </node>
 
     <node pkg="tf" type="static_transform_publisher" name="dvl_broadcaster"

--- a/simulation/sub8_gazebo/models/sub8/sub8.sdf
+++ b/simulation/sub8_gazebo/models/sub8/sub8.sdf
@@ -105,7 +105,7 @@
 
       <sensor name="down_camera" type="camera">
         <camera>
-          <pose>0.0537 0.1048 -0.2565  0 1.57 0</pose>
+          <pose>0.0537 0.1048 -0.2565 -1.57079632679 1.57079632679 0.0 </pose>
           <horizontal_fov>1.047</horizontal_fov>
           <image>
             <width>644</width>


### PR DESCRIPTION
This is the tf that I used to get the path alignment mission to work last pool day. 

Did not actually look at the camera positioning inside the box but all other rotations of 90 degrees that keep the camera facing down do not work.