### PR TITLE
CI: Adjustments for the pointgrey_camera_driver submodule in mil_common

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -11,8 +11,8 @@ ENV DOCKER true
 ENV INSTALL_SUB true
 ENV INSTALL_CUDA true
 
-# Allow the user to pass in the BlueView SDK with '--build-arg BVTSDK_PASSWORD="password"'
-ARG BVTSDK_PASSWORD
+# Allow the user to pass in the SDK password with '--build-arg SDK_PASSWORD="password"'
+ARG SDK_PASSWORD
 
 # Update the image and install tools needed to create the image
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -20,6 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install sudo \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install curl \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y install wget \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y install lightdm \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y autoremove --purge \
 	&& apt-get -y clean \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
There was an issue with the lightdm dependency of the Nvidia drivers that is fixed by preemptively installing it in headless mode. The former BlueView SDK password has also been repurposed for use with both the BlueView and Flycapture SDKs.