### PR TITLE
BUILD: add rostest dependency to thruser_mapper

### DIFF
--- a/gnc/sub8_thruster_mapper/CMakeLists.txt
+++ b/gnc/sub8_thruster_mapper/CMakeLists.txt
@@ -3,6 +3,7 @@ project(sub8_thruster_mapper)
 
 find_package(catkin REQUIRED COMPONENTS
   rospy
+  rostest
 )
 catkin_package()
 include_directories(

--- a/gnc/sub8_thruster_mapper/package.xml
+++ b/gnc/sub8_thruster_mapper/package.xml
@@ -8,6 +8,7 @@
   <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>rostest</build_depend>
   <run_depend>rospy</run_depend>
   <export>
   </export>


### PR DESCRIPTION
Had some occasional failure during catkin_make, resolved to missing rostest dependency