### PR TITLE
Fix dvl pose in urdf

### DIFF
--- a/simulation/sub8_gazebo/launch/duck.launch
+++ b/simulation/sub8_gazebo/launch/duck.launch
@@ -9,9 +9,5 @@
     args="$(find sub8_gazebo)/worlds/a_whole_new.world --verbose" />
   <node name="gazebo_gui" pkg="gazebo_ros" type="gzclient" respawn="false" if="$(arg gui)" />
 
-  <node
-    name="spawn_sub" pkg="gazebo_ros" type="spawn_model"
-    args="-urdf -param robot_description
-      -x 0. -y 0. -z 0. -model sub8"
-    output="screen" />
+  <include file="$(find sub8_gazebo)/launch/spawn.launch" />
 </launch>

--- a/simulation/sub8_gazebo/launch/spawn.launch
+++ b/simulation/sub8_gazebo/launch/spawn.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <node
+    name="spawn_sub" pkg="gazebo_ros" type="spawn_model"
+    args="-urdf -param robot_description
+      -x 0. -y 0. -z 0 -model sub8 -w water"
+    output="screen" />
+</launch>

--- a/simulation/sub8_gazebo/urdf/sub8.urdf.xacro
+++ b/simulation/sub8_gazebo/urdf/sub8.urdf.xacro
@@ -39,9 +39,7 @@
                               ax="0.015707963" ay="0.015707963" az="0.015707963"
                               lx="0.08825985" ly="0.08825985" lz="0.08825985" />
 
-  <!-- TODO: switch back to correct transform once CAD mesh is fixed so beam doesnt collide with self
-             should be xyz="0.0908 0 0.2459" rpy="0 0 0.785" -->
-  <xacro:mil_dvl name="dvl" xyz="0.0908 0 -1.0" rpy="0 0 0.785" rate="6.5" />
+  <xacro:mil_dvl name="dvl" xyz="0.0908 0 -0.2459" rpy="0 0 0.785" gazebo_offset="0 0 -1" rate="6.5" />
   <xacro:mil_depth name="depth" xyz="-0.235 0 -0.170" rpy="0 0 0" rate="20" />
 
   <!-- Other fixed frames -->


### PR DESCRIPTION
So I had to put in a hack to get sim working and forgot to fix it. I placed the dvl lower so the ray tracing didn't collide with the CAD model.... unfortunately this meant the static transform would be wrong to. I guess this wouldn't cause many problems but it might.

I put the pose back to the right one (see rviz to verify) and added an attribute to the gazebo plugin to move it in gazebo a little lower so it simulates correctly.

REQUIRES uf-mil/mil_common#202