### PR TITLE
Simulate pinger

### DIFF
--- a/command/sub8_launch/launch/sub8.launch
+++ b/command/sub8_launch/launch/sub8.launch
@@ -31,4 +31,7 @@
   <include if="$(eval environment == 'real')" file="$(find sub8_launch)/launch/subsystems/online_bagger.launch"/>
   <include file="$(find sub8_alarm)/launch/alarms.launch" />
   <include file="$(find sub8_launch)/launch/mission_server.launch" />
+  <include file="$(find sub8_launch)/launch/subsystems/passive_sonar.launch">
+    <arg name="environment" value="$(arg environment)" />
+  </include>
 </launch>

--- a/command/sub8_launch/launch/subsystems/passive_sonar.launch
+++ b/command/sub8_launch/launch/subsystems/passive_sonar.launch
@@ -1,10 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <launch>
-  <node pkg="sub8_launch" type="passive_sonar_conn" name="passive_sonar_conn" />
-  <node pkg="mil_passive_sonar" type="hydrophones" name="hydrophones_heading">
-    <param name="dist_h" value="2.286e-02" />
-    <param name="dist_h4" value="2.286e-02" />
-    <param name="v_sound" value="1482" />
-  </node>
+  <arg name="environment" default="real" />
+  <group if="$(eval environment == 'real')">
+    <node pkg="sub8_launch" type="passive_sonar_conn" name="passive_sonar_conn" />
+    <node pkg="mil_passive_sonar" type="hydrophones" name="hydrophones_heading">
+      <param name="dist_h" value="2.286e-02" />
+      <param name="dist_h4" value="2.286e-02" />
+      <param name="v_sound" value="1482" />
+    </node>
+  </group>
   <node pkg="mil_tools" type="vector_to_marker" name="hydrophones_visualization"
-        args="/hydrophones/direction /hydrophones/direction_marker --length 8" />
+        args="/hydrophones/direction /hydrophones/direction_marker --length 4" />
 </launch>

--- a/simulation/sub8_gazebo/package.xml
+++ b/simulation/sub8_gazebo/package.xml
@@ -17,6 +17,7 @@
   <depend>geometry_msgs</depend>
   <depend>message_generation</depend>
   <depend>xacro</depend>
+  <depend>mil_gazebo</depend>
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
 

--- a/simulation/sub8_gazebo/urdf/sub8.urdf.xacro
+++ b/simulation/sub8_gazebo/urdf/sub8.urdf.xacro
@@ -8,7 +8,7 @@
   <xacro:include filename="$(find mil_gazebo)/xacro/imu_magnetometer.xacro" />
   <xacro:include filename="$(find mil_gazebo)/xacro/depth.xacro" />
   <xacro:include filename="$(find mil_gazebo)/xacro/drag.xacro" />
-
+  <xacro:include filename="$(find mil_gazebo)/xacro/passive_sonar.xacro" />
 
   <!-- Base link of sub -->
   <link name="base_link">
@@ -41,10 +41,11 @@
 
   <xacro:mil_dvl name="dvl" xyz="0.0908 0 -0.2459" rpy="0 0 0.785" gazebo_offset="0 0 -1" rate="6.5" />
   <xacro:mil_depth name="depth" xyz="-0.235 0 -0.170" rpy="0 0 0" rate="20" />
+  <xacro:mil_passive_sonar name="hydrophones" xyz="-0.0908 0 -0.2459" rpy="0 0 1.571"
+                           model="transdec_pinger" freq="37000" amplitude="1000"/>
 
   <!-- Other fixed frames -->
   <xacro:mil_fixed_link name="blueview" parent="base_link" xyz="0.333 0 0.381" rpy="3.142 0 0" />
-  <xacro:mil_fixed_link name="hydrophones" parent="base_link" xyz="-0.0908 0 -0.2459" rpy="0 0 1.571" />
 
   <!-- Dynamics simulation -->
   <xacro:mil_drag use_param='True' />

--- a/simulation/sub8_gazebo/worlds/a_whole_new.world
+++ b/simulation/sub8_gazebo/worlds/a_whole_new.world
@@ -130,6 +130,12 @@
       </link>
     </model>
 
+    <include>
+      <name>transdec_pinger</name>
+      <uri>model://pinger</uri>
+      <pose>15 0 -2 0 0 0 </pose>
+    </include>
+
     <scene>
       <sky>
         <clouds>

--- a/sub.rviz
+++ b/sub.rviz
@@ -320,6 +320,14 @@ Visualization Manager:
       Show Visual Aids: false
       Update Topic: /guess_markers/update
       Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /hydrophones/direction_marker
+      Name: Pinger Heading
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 100; 100; 100


### PR DESCRIPTION
Requires uf-mil/mil_common#203

* Add a simulated pinger using the mil_common plugin. This does not actually simulate acoustics, but just sends out a vector from the reference sensor to a model in gazebo.
* Add passive_sonar into the main launch, so it runs when the sub is launched. This will also be sure to show the pinger visualization in the sim. I'm not sure if there was a particular reason this was not already the cast, so lmk if there was reason
* Modify the default rviz config to show the pinger heading visualziation

This should make it possible to simulate the pinger mission in the sim :)