### PR TITLE
Fix bit mask for hard kill

### DIFF
--- a/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
+++ b/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/handle.py
@@ -132,7 +132,7 @@ class ThrusterAndKillBoard(CANDeviceHandle):
         '''
         #print(ord(data[0]), ord(data[1]))
         # Hard Kill - bit 7
-        if (ord(data[0]) & 0x8):
+        if (ord(data[0]) & 0x80):
             self._last_hard_kill = True
         else:
             self._last_hard_kill = False


### PR DESCRIPTION
Pretty sure this is just a typo which introduced a bug in #400. If hearbeat loss was ever reported, this would falsely report a hard kill. I suppose this never happened in testing

Note this is also fixed in the larger refactor of this code in #407, but this is a one line fix you can use before reviewing that larger pr.