### PR TITLE
Re-simulate kill board

### DIFF
--- a/command/sub8_alarm/alarm_handlers/hw_kill.py
+++ b/command/sub8_alarm/alarm_handlers/hw_kill.py
@@ -3,10 +3,7 @@ from ros_alarms import HandlerBase, Alarm
 
 class HwKill(HandlerBase):
     alarm_name = 'hw-kill'
-    initally_raised = True
 
     def __init__(self):
-        # Alarm server wil set this as the intial state of kill alarm (starts killed)
-        self.initial_alarm = Alarm(self.alarm_name, True,
-                                   node_name='alarm_server',
-                                   problem_description='Initial kill')
+        pass
+

--- a/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/__init__.py
+++ b/drivers/sub8_thrust_and_kill_board/sub8_thrust_and_kill_board/__init__.py
@@ -1,4 +1,4 @@
 from handle import ThrusterAndKillBoard
 from simulation import ThrusterAndKillBoardSimulation
-from packets import ThrustPacket, GoMessage, KillMessage, HeartbeatMessage
+from packets import ThrustPacket, KillMessage, HeartbeatMessage, StatusMessage
 from thruster import Thruster


### PR DESCRIPTION
* Add class to represent the status messages received from the kill board
* Use this new abstraction in the kill board handler
* Use this new abstraction to simulate the kill board status so kill will work properly in sim (you won't need to `aclear hw-kill`
* Clean up problem description for hw-kill, so it will not report all causes of kill, not just one at random
* Remove initial kill from hw-kill alarm handler. This would falsely report hw-kill is killed when actually it just hasn't connected yet
* Wait for up to 3 seconds for the can driver to startup before trying to send it initial kill from motherboard. This should help some timing dependencies to make sure that initial kill does get carried along to kill board 